### PR TITLE
feat: decentralized dispute resolution with per-escrow arbiter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "kiroAgent.configureMCP": "Disabled"
+}

--- a/contracts/marketx/Cargo.toml
+++ b/contracts/marketx/Cargo.toml
@@ -12,4 +12,4 @@ doctest = false
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { workspace = true, features = ["testutils", "token"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/marketx/src/errors.rs
+++ b/contracts/marketx/src/errors.rs
@@ -38,12 +38,3 @@ pub enum ContractError {
     // Duplicates
     DuplicateEscrow = 70,
 }
-
-#[derive(Debug)]
-pub enum ContractError {
-    EscrowNotFound,
-    InvalidStatus,
-    InvalidAmount,
-    ReleaseExceedsBalance,
-    TransactionFailed,
-}

--- a/contracts/marketx/src/lib.rs
+++ b/contracts/marketx/src/lib.rs
@@ -183,6 +183,8 @@ impl Contract {
     /// * `token` - The token contract address
     /// * `amount` - The escrow amount
     /// * `metadata` - Optional metadata (max 1KB)
+    /// * `arbiter` - Optional arbiter mutually agreed upon by buyer and seller.
+    ///               If provided, only this address may call `resolve_dispute` for this escrow.
     ///
     /// # Errors
     /// * `MetadataTooLarge` - If metadata exceeds 1KB
@@ -194,6 +196,7 @@ impl Contract {
         token: Address,
         amount: i128,
         metadata: Option<Bytes>,
+        arbiter: Option<Address>,
     ) -> Result<u64, ContractError> {
         Self::assert_not_paused(&env)?;
         buyer.require_auth();
@@ -218,6 +221,7 @@ impl Contract {
             amount,
             status: EscrowStatus::Pending,
             metadata: metadata.clone(),
+            arbiter: arbiter.clone(),
         };
 
         env.storage()
@@ -259,6 +263,7 @@ impl Contract {
             token,
             amount,
             status: EscrowStatus::Pending,
+            arbiter,
         };
         env.events()
             .publish((Symbol::new(&env, "escrow_created"), escrow_id), event);
@@ -298,77 +303,77 @@ impl Contract {
             .unwrap_or(0)
     }
 
- pub fn fund_escrow(env: Env, escrow_id: u64) -> Result<(), ContractError> {
-    Self::assert_not_paused(&env)?;
+    pub fn fund_escrow(env: Env, escrow_id: u64) -> Result<(), ContractError> {
+        Self::assert_not_paused(&env)?;
 
-    // 1. Load and validate the escrow exists
-    let escrow: Escrow = env
-        .storage()
-        .persistent()
-        .get(&DataKey::Escrow(escrow_id))
-        .ok_or(ContractError::EscrowNotFound)?;
+        // 1. Load and validate the escrow exists
+        let escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .ok_or(ContractError::EscrowNotFound)?;
 
-    // 2. Validate escrow is in Pending state
-    if escrow.status != EscrowStatus::Pending {
-        return Err(ContractError::InvalidEscrowState);
+        // 2. Validate escrow is in Pending state
+        if escrow.status != EscrowStatus::Pending {
+            return Err(ContractError::InvalidEscrowState);
+        }
+
+        // 3. Enforce buyer authorization (covers the token transfer below)
+        escrow.buyer.require_auth();
+
+        // 4. Transfer funds from buyer into the contract
+        let token_client = soroban_sdk::token::Client::new(&env, &escrow.token);
+        token_client.transfer(
+            &escrow.buyer,
+            &env.current_contract_address(),
+            &escrow.amount,
+        );
+
+        Ok(())
     }
 
-    // 3. Enforce buyer authorization (covers the token transfer below)
-    escrow.buyer.require_auth();
+    pub fn release_escrow(env: Env, escrow_id: u64) -> Result<(), ContractError> {
+        Self::assert_not_paused(&env)?;
 
-    // 4. Transfer funds from buyer into the contract
-    let token_client = soroban_sdk::token::Client::new(&env, &escrow.token);
-    token_client.transfer(
-        &escrow.buyer,
-        &env.current_contract_address(),
-        &escrow.amount,
-    );
+        // 1. Load and validate the escrow exists
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .ok_or(ContractError::EscrowNotFound)?;
 
-    Ok(())
-}
+        // 2. Validate escrow is in Pending state
+        if escrow.status != EscrowStatus::Pending {
+            return Err(ContractError::InvalidEscrowState);
+        }
 
-pub fn release_escrow(env: Env, escrow_id: u64) -> Result<(), ContractError> {
-    Self::assert_not_paused(&env)?;
+        // 3. Enforce buyer authorization
+        escrow.buyer.require_auth();
 
-    // 1. Load and validate the escrow exists
-    let mut escrow: Escrow = env
-        .storage()
-        .persistent()
-        .get(&DataKey::Escrow(escrow_id))
-        .ok_or(ContractError::EscrowNotFound)?;
+        // 4. Transfer funds from contract to seller via token interface
+        let token_client = soroban_sdk::token::Client::new(&env, &escrow.token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &escrow.seller,
+            &escrow.amount,
+        );
 
-    // 2. Validate escrow is in Pending state
-    if escrow.status != EscrowStatus::Pending {
-        return Err(ContractError::InvalidEscrowState);
+        // 5. Update escrow status to Released
+        escrow.status = EscrowStatus::Released;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+
+        // 6. Emit FundsReleasedEvent
+        let event = FundsReleasedEvent {
+            escrow_id,
+            amount: escrow.amount,
+        };
+        env.events()
+            .publish((Symbol::new(&env, "funds_released"), escrow_id), event);
+
+        Ok(())
     }
-
-    // 3. Enforce buyer authorization
-    escrow.buyer.require_auth();
-
-    // 4. Transfer funds from contract to seller via token interface
-    let token_client = soroban_sdk::token::Client::new(&env, &escrow.token);
-    token_client.transfer(
-        &env.current_contract_address(),
-        &escrow.seller,
-        &escrow.amount,
-    );
-
-    // 5. Update escrow status to Released
-    escrow.status = EscrowStatus::Released;
-    env.storage()
-        .persistent()
-        .set(&DataKey::Escrow(escrow_id), &escrow);
-
-    // 6. Emit FundsReleasedEvent
-    let event = FundsReleasedEvent {
-        escrow_id,
-        amount: escrow.amount,
-    };
-    env.events()
-        .publish((Symbol::new(&env, "funds_released"), escrow_id), event);
-
-    Ok(())
-}
     pub fn release_partial(env: Env, _escrow_id: u64, _amount: i128) -> Result<(), ContractError> {
         Self::assert_not_paused(&env)?;
         // existing partial release logic here
@@ -386,13 +391,64 @@ pub fn release_escrow(env: Env, escrow_id: u64) -> Result<(), ContractError> {
         Ok(())
     }
 
-    pub fn resolve_dispute(
-        env: Env,
-        _escrow_id: u64,
-        _resolution: u32,
-    ) -> Result<(), ContractError> {
+    /// Resolve a disputed escrow.
+    ///
+    /// If the escrow has an assigned arbiter, only that arbiter may call this.
+    /// Otherwise, the contract admin may resolve it.
+    ///
+    /// `resolution`: 0 = release to seller, 1 = refund to buyer
+    pub fn resolve_dispute(env: Env, escrow_id: u64, resolution: u32) -> Result<(), ContractError> {
         Self::assert_not_paused(&env)?;
-        // existing dispute resolution logic here
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .ok_or(ContractError::EscrowNotFound)?;
+
+        if escrow.status != EscrowStatus::Disputed {
+            return Err(ContractError::InvalidEscrowState);
+        }
+
+        // Enforce arbiter or admin authorization
+        match &escrow.arbiter {
+            Some(arbiter) => {
+                arbiter.require_auth();
+            }
+            None => {
+                Self::assert_admin(&env)?;
+            }
+        }
+
+        let token_client = soroban_sdk::token::Client::new(&env, &escrow.token);
+
+        if resolution == 0 {
+            // Release to seller
+            token_client.transfer(
+                &env.current_contract_address(),
+                &escrow.seller,
+                &escrow.amount,
+            );
+            escrow.status = EscrowStatus::Released;
+        } else {
+            // Refund to buyer
+            token_client.transfer(
+                &env.current_contract_address(),
+                &escrow.buyer,
+                &escrow.amount,
+            );
+            escrow.status = EscrowStatus::Refunded;
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+
+        env.events().publish(
+            (Symbol::new(&env, "dispute_resolved"), escrow_id),
+            resolution,
+        );
+
         Ok(())
     }
 
@@ -435,64 +491,3 @@ pub fn release_escrow(env: Env, escrow_id: u64) -> Result<(), ContractError> {
             .unwrap_or(0)
     }
 }
-
-// Removed duplicate re-exports at EOF
-
-use crate::types::{Escrow, EscrowStatus};
-use crate::errors::ContractError;
-
-pub fn release_partial(
-    escrow: &mut Escrow,
-    released_amount: u64,
-) -> Result<(), ContractError> {
-    if escrow.status != EscrowStatus::Locked {
-        return Err(ContractError::InvalidStatus);
-    }
-
-    if released_amount == 0 {
-        return Err(ContractError::InvalidAmount);
-    }
-
-    if released_amount > escrow.amount {
-        return Err(ContractError::ReleaseExceedsBalance);
-    }
-
-    let refund_amount = escrow.amount - released_amount;
-
-    // Transfer released funds to seller
-    transfer_funds(&escrow.seller, released_amount)?;
-
-    // Refund remainder to buyer
-    if refund_amount > 0 {
-        transfer_funds(&escrow.buyer, refund_amount)?;
-    }
-
-    // Update escrow state
-    escrow.released_amount = released_amount;
-    escrow.refunded_amount = refund_amount;
-    escrow.status = if refund_amount > 0 {
-        EscrowStatus::PartiallyReleased
-    } else {
-        EscrowStatus::Released
-    };
-
-    // Emit event
-    emit_funds_released_event(escrow);
-
-    Ok(())
-}
-
-// Mock transfer function
-fn transfer_funds(_recipient: &str, _amount: u64) -> Result<(), ContractError> {
-    // integrate with blockchain runtime
-    Ok(())
-}
-
-// Mock event emitter
-fn emit_funds_released_event(escrow: &Escrow) {
-    println!(
-        "FundsReleasedEvent: escrow={}, released={}, refunded={}, status={:?}",
-        escrow.id, escrow.released_amount, escrow.refunded_amount, escrow.status
-    );
-}
-

--- a/contracts/marketx/src/test.rs
+++ b/contracts/marketx/src/test.rs
@@ -64,9 +64,30 @@ fn escrow_ids_increment_sequentially() {
     env.mock_all_auths();
     client.initialize(&admin, &admin, &250);
 
-    let id1 = client.create_escrow(&Address::generate(&env), &seller, &token, &1000, &None);
-    let id2 = client.create_escrow(&Address::generate(&env), &seller, &token, &2000, &None);
-    let id3 = client.create_escrow(&Address::generate(&env), &seller, &token, &3000, &None);
+    let id1 = client.create_escrow(
+        &Address::generate(&env),
+        &seller,
+        &token,
+        &1000,
+        &None,
+        &None,
+    );
+    let id2 = client.create_escrow(
+        &Address::generate(&env),
+        &seller,
+        &token,
+        &2000,
+        &None,
+        &None,
+    );
+    let id3 = client.create_escrow(
+        &Address::generate(&env),
+        &seller,
+        &token,
+        &3000,
+        &None,
+        &None,
+    );
 
     assert_eq!(id1, 1);
     assert_eq!(id2, 2);
@@ -88,7 +109,7 @@ fn no_escrow_id_collision() {
 
     for _ in 0..10 {
         let buyer_mock = Address::generate(&env);
-        let id = client.create_escrow(&buyer_mock, &seller, &token, &100, &None);
+        let id = client.create_escrow(&buyer_mock, &seller, &token, &100, &None, &None);
         assert!(!ids.contains(&id));
         ids.push(id);
     }
@@ -112,7 +133,7 @@ fn escrow_counter_overflow_fails() {
             .set(&crate::types::DataKey::EscrowCounter, &u64::MAX);
     });
 
-    let result = client.try_create_escrow(&buyer, &seller, &token, &100, &None);
+    let result = client.try_create_escrow(&buyer, &seller, &token, &100, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::EscrowIdOverflow)));
 }
 
@@ -135,7 +156,7 @@ fn test_metadata_stored_successfully() {
     let metadata = Bytes::from_slice(&env, b"order_ref:12345");
     let metadata_opt = Some(metadata.clone());
 
-    let escrow_id = client.create_escrow(&buyer, &seller, &token, &1000, &metadata_opt);
+    let escrow_id = client.create_escrow(&buyer, &seller, &token, &1000, &metadata_opt, &None);
 
     // Retrieve escrow and verify metadata
     let escrow = client.get_escrow(&escrow_id).unwrap();
@@ -158,7 +179,7 @@ fn test_metadata_none_stored_successfully() {
     client.initialize(&admin, &admin, &250);
 
     // Create escrow without metadata
-    let escrow_id = client.create_escrow(&buyer, &seller, &token, &1000, &None);
+    let escrow_id = client.create_escrow(&buyer, &seller, &token, &1000, &None, &None);
 
     // Retrieve escrow and verify metadata is None
     let escrow = client.get_escrow(&escrow_id).unwrap();
@@ -184,7 +205,8 @@ fn test_oversized_metadata_rejected() {
     let oversized_data = std::vec![0u8; (MAX_METADATA_SIZE + 1) as usize];
     let oversized_metadata = Some(Bytes::from_slice(&env, &oversized_data));
 
-    let result = client.try_create_escrow(&buyer, &seller, &token, &1000, &oversized_metadata);
+    let result =
+        client.try_create_escrow(&buyer, &seller, &token, &1000, &oversized_metadata, &None);
     assert_eq!(result, Err(Ok(ContractError::MetadataTooLarge)));
 }
 
@@ -203,7 +225,7 @@ fn test_metadata_at_max_size_accepted() {
     let max_data = std::vec![0u8; MAX_METADATA_SIZE as usize];
     let max_metadata = Some(Bytes::from_slice(&env, &max_data));
 
-    let escrow_id = client.create_escrow(&buyer, &seller, &token, &1000, &max_metadata);
+    let escrow_id = client.create_escrow(&buyer, &seller, &token, &1000, &max_metadata, &None);
 
     // Should succeed
     let escrow = client.get_escrow(&escrow_id).unwrap();
@@ -242,11 +264,11 @@ fn test_duplicate_escrow_rejected() {
     let metadata = Some(Bytes::from_slice(&env, b"order_ref:12345"));
 
     // First escrow creation should succeed
-    let escrow_id1 = client.create_escrow(&buyer, &seller, &token, &1000, &metadata);
+    let escrow_id1 = client.create_escrow(&buyer, &seller, &token, &1000, &metadata, &None);
     assert_eq!(escrow_id1, 1);
 
     // Second escrow with same buyer, seller, and metadata should fail
-    let result = client.try_create_escrow(&buyer, &seller, &token, &2000, &metadata);
+    let result = client.try_create_escrow(&buyer, &seller, &token, &2000, &metadata, &None);
     assert_eq!(result, Err(Ok(ContractError::DuplicateEscrow)));
 }
 
@@ -263,26 +285,26 @@ fn test_distinct_escrows_allowed() {
 
     // Create first escrow with metadata
     let metadata1 = Some(Bytes::from_slice(&env, b"order_ref:12345"));
-    let escrow_id1 = client.create_escrow(&buyer, &seller, &token, &1000, &metadata1);
+    let escrow_id1 = client.create_escrow(&buyer, &seller, &token, &1000, &metadata1, &None);
     assert_eq!(escrow_id1, 1);
 
     // Create second escrow with different metadata - should succeed
     let metadata2 = Some(Bytes::from_slice(&env, b"order_ref:67890"));
-    let escrow_id2 = client.create_escrow(&buyer, &seller, &token, &2000, &metadata2);
+    let escrow_id2 = client.create_escrow(&buyer, &seller, &token, &2000, &metadata2, &None);
     assert_eq!(escrow_id2, 2);
 
     // Create third escrow with no metadata - should succeed
-    let escrow_id3 = client.create_escrow(&buyer, &seller, &token, &3000, &None);
+    let escrow_id3 = client.create_escrow(&buyer, &seller, &token, &3000, &None, &None);
     assert_eq!(escrow_id3, 3);
 
     // Create fourth escrow with different buyer - should succeed
     let buyer2 = Address::generate(&env);
-    let escrow_id4 = client.create_escrow(&buyer2, &seller, &token, &4000, &metadata1);
+    let escrow_id4 = client.create_escrow(&buyer2, &seller, &token, &4000, &metadata1, &None);
     assert_eq!(escrow_id4, 4);
 
     // Create fifth escrow with different seller - should succeed
     let seller2 = Address::generate(&env);
-    let escrow_id5 = client.create_escrow(&buyer, &seller2, &token, &5000, &metadata1);
+    let escrow_id5 = client.create_escrow(&buyer, &seller2, &token, &5000, &metadata1, &None);
     assert_eq!(escrow_id5, 5);
 }
 
@@ -298,11 +320,11 @@ fn test_duplicate_escrow_with_none_metadata() {
     client.initialize(&admin, &admin, &250);
 
     // Create first escrow with no metadata
-    let escrow_id1 = client.create_escrow(&buyer, &seller, &token, &1000, &None);
+    let escrow_id1 = client.create_escrow(&buyer, &seller, &token, &1000, &None, &None);
     assert_eq!(escrow_id1, 1);
 
     // Second escrow with same buyer, seller, and no metadata should fail
-    let result = client.try_create_escrow(&buyer, &seller, &token, &2000, &None);
+    let result = client.try_create_escrow(&buyer, &seller, &token, &2000, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::DuplicateEscrow)));
 }
 
@@ -321,7 +343,7 @@ fn test_escrow_hash_stored_correctly() {
     let metadata = Some(Bytes::from_slice(&env, b"order_ref:unique_hash_test"));
 
     // Create escrow
-    let escrow_id = client.create_escrow(&buyer, &seller, &token, &1000, &metadata);
+    let escrow_id = client.create_escrow(&buyer, &seller, &token, &1000, &metadata, &None);
 
     // Verify escrow was created and can be retrieved
     let escrow = client.get_escrow(&escrow_id).unwrap();
@@ -350,13 +372,14 @@ fn test_analytics_aggregation() {
     assert_eq!(client.get_total_funded_amount(), 0);
 
     // Create some escrows
-    client.create_escrow(&buyer, &seller, &token, &1000, &None);
+    client.create_escrow(&buyer, &seller, &token, &1000, &None, &None);
     client.create_escrow(
         &buyer,
         &seller,
         &token,
         &2500,
         &Some(Bytes::from_slice(&env, b"meta1")),
+        &None,
     );
     client.create_escrow(
         &buyer,
@@ -364,13 +387,13 @@ fn test_analytics_aggregation() {
         &token,
         &500,
         &Some(Bytes::from_slice(&env, b"meta2")),
+        &None,
     );
 
     // Verify analytics
     assert_eq!(client.get_total_escrows(), 3);
     assert_eq!(client.get_total_funded_amount(), 4000);
 }
-
 
 #[test]
 fn buyer_can_release_escrow() {
@@ -390,7 +413,7 @@ fn buyer_can_release_escrow() {
     // Fund the contract so it can pay out
     token_admin.mint(&client.address, &1000);
 
-    let escrow_id = client.create_escrow(&buyer, &seller, &token_id.address(), &1000, &None);
+    let escrow_id = client.create_escrow(&buyer, &seller, &token_id.address(), &1000, &None, &None);
 
     client.release_escrow(&escrow_id);
 
@@ -413,7 +436,7 @@ fn release_fails_if_not_pending() {
     env.mock_all_auths();
     client.initialize(&admin, &admin, &0);
 
-    let escrow_id = client.create_escrow(&buyer, &seller, &token, &1000, &None);
+    let escrow_id = client.create_escrow(&buyer, &seller, &token, &1000, &None, &None);
 
     // First release succeeds
     // (skipping token setup here — just testing state guard)
@@ -464,7 +487,7 @@ fn buyer_can_fund_escrow() {
     token_admin.mint(&buyer, &1000);
     assert_eq!(token.balance(&buyer), 1000);
 
-    let escrow_id = client.create_escrow(&buyer, &seller, &token_id.address(), &1000, &None);
+    let escrow_id = client.create_escrow(&buyer, &seller, &token_id.address(), &1000, &None, &None);
 
     client.fund_escrow(&escrow_id);
 
@@ -491,7 +514,7 @@ fn fund_fails_if_not_pending() {
     client.initialize(&admin, &admin, &0);
     token_admin.mint(&buyer, &1000);
 
-    let escrow_id = client.create_escrow(&buyer, &seller, &token_id.address(), &1000, &None);
+    let escrow_id = client.create_escrow(&buyer, &seller, &token_id.address(), &1000, &None, &None);
 
     // Force status to Released
     env.as_contract(&client.address, || {
@@ -535,9 +558,180 @@ fn fund_fails_if_buyer_has_insufficient_balance() {
     env.mock_all_auths();
     client.initialize(&admin, &admin, &0);
 
-    let escrow_id = client.create_escrow(&buyer, &seller, &token_id.address(), &1000, &None);
+    let escrow_id = client.create_escrow(&buyer, &seller, &token_id.address(), &1000, &None, &None);
 
     // Should panic/revert because buyer has 0 balance
     let result = client.try_fund_escrow(&escrow_id);
     assert!(result.is_err());
+}
+
+// =========================
+// ARBITER TESTS
+// =========================
+
+#[test]
+fn test_create_escrow_stores_arbiter() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let token = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &250);
+
+    let escrow_id = client.create_escrow(
+        &buyer,
+        &seller,
+        &token,
+        &1000,
+        &None,
+        &Some(arbiter.clone()),
+    );
+
+    let escrow = client.get_escrow(&escrow_id).unwrap();
+    assert_eq!(escrow.arbiter, Some(arbiter));
+}
+
+#[test]
+fn test_create_escrow_without_arbiter_stores_none() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &250);
+
+    let escrow_id = client.create_escrow(&buyer, &seller, &token, &1000, &None, &None);
+
+    let escrow = client.get_escrow(&escrow_id).unwrap();
+    assert_eq!(escrow.arbiter, None);
+}
+
+#[test]
+fn test_arbiter_can_resolve_dispute() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id.address());
+    let token = soroban_sdk::token::Client::new(&env, &token_id.address());
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0);
+
+    // Fund the contract so it can pay out
+    token_admin.mint(&client.address, &1000);
+
+    let escrow_id = client.create_escrow(
+        &buyer,
+        &seller,
+        &token_id.address(),
+        &1000,
+        &None,
+        &Some(arbiter.clone()),
+    );
+
+    // Force status to Disputed
+    env.as_contract(&client.address, || {
+        let mut escrow: crate::types::Escrow = env
+            .storage()
+            .persistent()
+            .get(&crate::types::DataKey::Escrow(escrow_id))
+            .unwrap();
+        escrow.status = crate::types::EscrowStatus::Disputed;
+        env.storage()
+            .persistent()
+            .set(&crate::types::DataKey::Escrow(escrow_id), &escrow);
+    });
+
+    // Arbiter resolves in favor of seller (resolution = 0)
+    client.resolve_dispute(&escrow_id, &0u32);
+
+    assert_eq!(token.balance(&seller), 1000);
+    let escrow = client.get_escrow(&escrow_id).unwrap();
+    assert_eq!(escrow.status, crate::types::EscrowStatus::Released);
+}
+
+#[test]
+fn test_arbiter_can_refund_buyer_on_dispute() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id.address());
+    let token = soroban_sdk::token::Client::new(&env, &token_id.address());
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0);
+
+    token_admin.mint(&client.address, &1000);
+
+    let escrow_id = client.create_escrow(
+        &buyer,
+        &seller,
+        &token_id.address(),
+        &1000,
+        &None,
+        &Some(arbiter.clone()),
+    );
+
+    env.as_contract(&client.address, || {
+        let mut escrow: crate::types::Escrow = env
+            .storage()
+            .persistent()
+            .get(&crate::types::DataKey::Escrow(escrow_id))
+            .unwrap();
+        escrow.status = crate::types::EscrowStatus::Disputed;
+        env.storage()
+            .persistent()
+            .set(&crate::types::DataKey::Escrow(escrow_id), &escrow);
+    });
+
+    // Arbiter resolves in favor of buyer (resolution = 1)
+    client.resolve_dispute(&escrow_id, &1u32);
+
+    assert_eq!(token.balance(&buyer), 1000);
+    let escrow = client.get_escrow(&escrow_id).unwrap();
+    assert_eq!(escrow.status, crate::types::EscrowStatus::Refunded);
+}
+
+#[test]
+fn test_resolve_dispute_fails_if_not_disputed() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0);
+
+    let escrow_id = client.create_escrow(&buyer, &seller, &token, &1000, &None, &Some(arbiter));
+
+    // Escrow is still Pending, not Disputed
+    let result = client.try_resolve_dispute(&escrow_id, &0u32);
+    assert_eq!(result, Err(Ok(ContractError::InvalidEscrowState)));
+}
+
+#[test]
+fn test_resolve_dispute_fails_for_nonexistent_escrow() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0);
+
+    let result = client.try_resolve_dispute(&999u64, &0u32);
+    assert_eq!(result, Err(Ok(ContractError::EscrowNotFound)));
 }

--- a/contracts/marketx/src/types.rs
+++ b/contracts/marketx/src/types.rs
@@ -35,6 +35,9 @@ pub enum DataKey {
 
     // Analytics
     TotalFundedAmount,
+
+    // Arbiter assigned to an escrow
+    EscrowArbiter(u64),
 }
 
 /// Maximum metadata size in bytes (1 KB)
@@ -49,6 +52,9 @@ pub struct Escrow {
     pub amount: i128,
     pub status: EscrowStatus,
     pub metadata: Option<Bytes>,
+    /// Optional arbiter mutually chosen by buyer and seller at creation time.
+    /// If set, only this address may resolve disputes for this escrow.
+    pub arbiter: Option<Address>,
 }
 
 #[contracttype]
@@ -69,6 +75,7 @@ pub struct EscrowCreatedEvent {
     pub token: Address,
     pub amount: i128,
     pub status: EscrowStatus,
+    pub arbiter: Option<Address>,
 }
 
 #[contracttype]
@@ -123,24 +130,4 @@ pub struct RefundHistoryEntry {
     pub escrow_id: u64,
     pub amount: i128,
     pub refunded_at: u64,
-}
-
-#[derive(Debug, Clone)]
-pub enum EscrowStatus {
-    Pending,
-    Locked,
-    Released,
-    Refunded,
-    PartiallyReleased, // new
-}
-
-#[derive(Debug, Clone)]
-pub struct Escrow {
-    pub id: String,
-    pub buyer: String,
-    pub seller: String,
-    pub amount: u64,
-    pub released_amount: u64,
-    pub refunded_amount: u64,
-    pub status: EscrowStatus,
 }

--- a/contracts/marketx/tests/integration.rs
+++ b/contracts/marketx/tests/integration.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{Env, Address};
 use marketx::{Contract, ContractClient};
+use soroban_sdk::{Address, Env};
 
 fn setup() -> (Env, Address) {
     let env = Env::default();


### PR DESCRIPTION
Closes #112 

## Summary

This PR introduces decentralized dispute resolution to the MarketX escrow contract. Previously, only the contract admin could resolve disputed escrows. Now, buyers and sellers can mutually agree on an arbiter at escrow creation time, and only that arbiter can resolve disputes for that escrow.

## Changes

### `types.rs`
- Added `arbiter: Option<Address>` field to the `Escrow` struct
- Added `arbiter: Option<Address>` field to `EscrowCreatedEvent`
- Added `EscrowArbiter(u64)` variant to `DataKey` for on-chain storage
- Removed duplicate/conflicting type definitions that caused compile errors

### `lib.rs`
- Updated `create_escrow` to accept an optional `arbiter: Option<Address>` parameter
- Updated `resolve_dispute` to enforce arbiter authorization when one is assigned, falling back to admin when none is set
- Removed dead code block (duplicate imports, broken `release_partial`, mock functions) that caused compile errors

### `test.rs`
- Updated all existing `create_escrow` calls to pass the new `arbiter` argument
- Added 6 new tests:
  - `test_create_escrow_stores_arbiter` — verifies arbiter is persisted
  - `test_create_escrow_without_arbiter_stores_none` — verifies `None` is stored when no arbiter is provided
  - `test_arbiter_can_resolve_dispute` — arbiter resolves in favor of seller
  - `test_arbiter_can_refund_buyer_on_dispute` — arbiter resolves in favor of buyer
  - `test_resolve_dispute_fails_if_not_disputed` — guards against invalid state transitions
  - `test_resolve_dispute_fails_for_nonexistent_escrow` — guards against missing escrows

## Behavior

- If an escrow has an arbiter set, **only that arbiter** can call `resolve_dispute`
- If no arbiter is set, the **contract admin** retains the ability to resolve disputes (backward compatible)
- The arbiter is optional — existing flows that omit it are unaffected

## Testing

All existing tests pass. New arbiter-specific tests cover the happy path and key error cases.