### PR TITLE
feat: add fee exemption whitelist for partners/internal accounts

### DIFF
--- a/contracts/marketx/src/lib.rs
+++ b/contracts/marketx/src/lib.rs
@@ -98,15 +98,11 @@ use soroban_sdk::xdr::ToXdr;
 
 pub use errors::ContractError;
 pub use types::{
-    AdminTransferredEvent, CounterEvidenceSubmittedEvent, DataKey, Escrow, EscrowCreatedEvent,
-    EscrowItem, EscrowStatus, FeeChangedEvent, FeeCollectedEvent, FundsReleasedEvent,
-    RefundHistoryEntry, RefundReason, RefundRequest, RefundRequestedEvent, RefundStatus,
-    StatusChangeEvent, MAX_ITEMS_PER_ESCROW, MAX_METADATA_SIZE,
-    CancellationProposedEvent,
-    EscrowExpiredEvent, EscrowItem, EscrowStatus, FeeChangedEvent, FeeCollectedEvent,
-    FundsReleasedEvent, RefundHistoryEntry, RefundReason, RefundRequest, RefundRequestedEvent,
-    RefundStatus, StatusChangeEvent, MAX_ITEMS_PER_ESCROW, MAX_METADATA_SIZE,
-    UNFUNDED_EXPIRY_LEDGERS,
+    AdminTransferredEvent, CancellationProposedEvent, CounterEvidenceSubmittedEvent, DataKey,
+    Escrow, EscrowCreatedEvent, EscrowExpiredEvent, EscrowItem, EscrowStatus, FeeChangedEvent,
+    FeeCollectedEvent, FeeExemptionEvent, FundsReleasedEvent, RefundHistoryEntry, RefundReason,
+    RefundRequest, RefundRequestedEvent, RefundStatus, StatusChangeEvent, MAX_ITEMS_PER_ESCROW,
+    MAX_METADATA_SIZE, UNFUNDED_EXPIRY_LEDGERS,
 };
 
 #[cfg(test)]
@@ -652,12 +648,22 @@ impl Contract {
         let from_status = escrow.status.clone();
 
         // 4. Calculate fee: amount * fee_bps / 10_000 (integer floor division)
+        // Whitelisted buyers (partners/internal) pay zero fees.
+        let is_exempt: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::FeeWhitelist(escrow.buyer.clone()))
+            .unwrap_or(false);
         let fee_bps: u32 = env
             .storage()
             .persistent()
             .get(&DataKey::FeeBps)
             .unwrap_or(0);
-        let fee: i128 = escrow.amount * (fee_bps as i128) / 10_000;
+        let fee: i128 = if is_exempt {
+            0
+        } else {
+            escrow.amount * (fee_bps as i128) / 10_000
+        };
         let seller_amount = escrow.amount - fee;
 
         let token_client = soroban_sdk::token::Client::new(&env, &escrow.token);
@@ -1261,6 +1267,34 @@ impl Contract {
             .persistent()
             .get(&DataKey::FeeBps)
             .unwrap_or(0)
+    }
+
+    /// Add an address to the fee exemption whitelist. Admin only.
+    pub fn add_fee_whitelist(env: Env, address: Address) -> Result<(), ContractError> {
+        let admin = Self::assert_admin(&env)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::FeeWhitelist(address.clone()), &true);
+        FeeExemptionEvent { address, exempted: true, actor: admin }.publish(&env);
+        Ok(())
+    }
+
+    /// Remove an address from the fee exemption whitelist. Admin only.
+    pub fn remove_fee_whitelist(env: Env, address: Address) -> Result<(), ContractError> {
+        let admin = Self::assert_admin(&env)?;
+        env.storage()
+            .persistent()
+            .remove(&DataKey::FeeWhitelist(address.clone()));
+        FeeExemptionEvent { address, exempted: false, actor: admin }.publish(&env);
+        Ok(())
+    }
+
+    /// Check whether an address is fee-exempt.
+    pub fn is_fee_exempt(env: Env, address: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::FeeWhitelist(address))
+            .unwrap_or(false)
     }
 
     /// Get a refund request by ID.

--- a/contracts/marketx/src/test.rs
+++ b/contracts/marketx/src/test.rs
@@ -1902,3 +1902,134 @@ fn test_cancel_unfunded_allows_escrow_recreation() {
     let new_id = client.create_escrow(&buyer, &seller, &token, &1000, &None, &None, &None);
     assert!(client.get_escrow(&new_id).is_some());
 }
+
+// =========================
+// FEE EXEMPTION WHITELIST TESTS
+// =========================
+
+#[test]
+fn test_add_and_check_fee_whitelist() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let partner = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &250);
+
+    assert!(!client.is_fee_exempt(&partner));
+
+    client.add_fee_whitelist(&partner);
+    assert!(client.is_fee_exempt(&partner));
+}
+
+#[test]
+fn test_remove_fee_whitelist() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let partner = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &250);
+
+    client.add_fee_whitelist(&partner);
+    assert!(client.is_fee_exempt(&partner));
+
+    client.remove_fee_whitelist(&partner);
+    assert!(!client.is_fee_exempt(&partner));
+}
+
+#[test]
+#[should_panic]
+fn test_non_admin_cannot_add_whitelist() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    let partner = Address::generate(&env);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &client.address,
+                fn_name: "initialize",
+                args: (&admin, &admin, 250u32).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .initialize(&admin, &admin, &250);
+
+    // non_admin tries to whitelist — should trap
+    client
+        .mock_auths(&[MockAuth {
+            address: &non_admin,
+            invoke: &MockAuthInvoke {
+                contract: &client.address,
+                fn_name: "add_fee_whitelist",
+                args: (&partner,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .add_fee_whitelist(&partner);
+}
+
+#[test]
+fn test_whitelisted_buyer_pays_no_fee() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+
+    let xlm_sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let xlm_address = xlm_sac.address();
+    let xlm_admin = soroban_sdk::token::StellarAssetClient::new(&env, &xlm_address);
+    let xlm_token = soroban_sdk::token::Client::new(&env, &xlm_address);
+
+    env.mock_all_auths();
+    // 250 bps = 2.5% fee
+    client.initialize(&admin, &admin, &250);
+
+    let amount: i128 = 10_000;
+    xlm_admin.mint(&buyer, &amount);
+
+    // Whitelist the buyer
+    client.add_fee_whitelist(&buyer);
+
+    let escrow_id = client.create_escrow(&buyer, &seller, &xlm_address, &amount, &None, &None, &None);
+    client.fund_escrow(&escrow_id);
+    client.release_escrow(&escrow_id);
+
+    // Seller receives full amount (no fee deducted)
+    assert_eq!(xlm_token.balance(&seller), amount);
+    // Fee collector (admin) received nothing
+    assert_eq!(xlm_token.balance(&admin), 0);
+}
+
+#[test]
+fn test_non_whitelisted_buyer_pays_fee() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+
+    let xlm_sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let xlm_address = xlm_sac.address();
+    let xlm_admin = soroban_sdk::token::StellarAssetClient::new(&env, &xlm_address);
+    let xlm_token = soroban_sdk::token::Client::new(&env, &xlm_address);
+
+    env.mock_all_auths();
+    // 250 bps = 2.5% fee
+    client.initialize(&admin, &admin, &250);
+
+    let amount: i128 = 10_000;
+    xlm_admin.mint(&buyer, &amount);
+
+    let escrow_id = client.create_escrow(&buyer, &seller, &xlm_address, &amount, &None, &None, &None);
+    client.fund_escrow(&escrow_id);
+    client.release_escrow(&escrow_id);
+
+    let expected_fee: i128 = amount * 250 / 10_000; // 250
+    let expected_seller: i128 = amount - expected_fee; // 9_750
+
+    assert_eq!(xlm_token.balance(&seller), expected_seller);
+    assert_eq!(xlm_token.balance(&admin), expected_fee);
+}

--- a/contracts/marketx/src/types.rs
+++ b/contracts/marketx/src/types.rs
@@ -56,6 +56,7 @@ pub enum DataKey {
     EscrowIds,
 
     TotalReleasedAmount,
+    FeeWhitelist(Address),
 }
 
 pub const MAX_METADATA_SIZE: u32 = 1024;
@@ -239,4 +240,12 @@ pub struct CounterEvidenceSubmittedEvent {
     pub escrow_id: u64,
     pub responder: Address,
     pub counter_evidence_hash: Option<Bytes>,
+}
+
+#[contractevent(topics = ["fee_exemption"], data_format = "vec")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeeExemptionEvent {
+    pub address: Address,
+    pub exempted: bool,
+    pub actor: Address,
 }


### PR DESCRIPTION
fixed #172



feat: add fee exemption whitelist for partners and internal accounts
  
  Some partners and internal test accounts should not pay fees when
  releasing escrow funds. This adds a persistent per-address whitelist
  that the admin can manage, and integrates the exemption check into
  the release_escrow flow.
  
  ## Changes
  
  ### types.rs
  - Add `DataKey::FeeWhitelist(Address)` — persistent storage key keyed
    by address, holds a bool flag
  - Add `FeeExemptionEvent` — emitted whenever an address is added to or
    removed from the whitelist; fields: `address`, `exempted: bool`, `actor`
  
  ### lib.rs
  - Fix duplicate `pub use` block (pre-existing issue cleaned up)
  - Export `FeeExemptionEvent` from the crate's public interface
  - `add_fee_whitelist(address)` — admin-only; sets the whitelist flag and
    emits `FeeExemptionEvent { exempted: true }`
  - `remove_fee_whitelist(address)` — admin-only; removes the flag and
    emits `FeeExemptionEvent { exempted: false }`
  - `is_fee_exempt(address) -> bool` — permissionless read; returns false
    if the address has never been whitelisted
  - `release_escrow` — before computing the fee, reads
    `FeeWhitelist(buyer)`; if the buyer is exempt, fee is forced to 0 and
    the seller receives the full escrow amount; non-exempt buyers continue
    to pay the configured fee_bps rate
  
  ### test.rs
  - `test_add_and_check_fee_whitelist` — adding an address sets is_fee_exempt to true
  - `test_remove_fee_whitelist` — removing an address clears the exemption
  - `test_non_admin_cannot_add_whitelist` — non-admin call panics (auth trap)
  - `test_whitelisted_buyer_pays_no_fee` — seller receives 100% of escrow
    amount; fee collector balance remains 0
  - `test_non_whitelisted_buyer_pays_fee` — seller receives amount minus
    fee; fee collector receives the correct fee amount
  
  ## Design decisions
  - Whitelist is stored as individual persistent entries per address rather
    than a single Vec, so lookups are O(1) and do not require iterating a
    list
  - Exemption is checked on the buyer address (the party who initiates
    release), which is the natural identity for partner/internal accounts
  - The whitelist has no effect on dispute resolution or cancellation paths;
    only release_escrow is in scope for fee collection
  
  To amend the existing commit with this message:
  
  git commit --amend -m "$(cat <<'EOF'
  feat: add fee exemption whitelist for partners and internal accounts
  ...
  EOF
  )"
  
  Or interactively:
  
  git commit --amend