### PR TITLE
feat: fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,159 @@
+# Contributing to MarketX Contract
+
+Thank you for contributing to the MarketX smart contract. This guide covers everything you need to set up, build, test, and submit quality contributions.
+
+---
+
+## Prerequisites
+
+### 1. Rust (stable toolchain)
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup update stable
+rustup default stable
+```
+
+### 2. WASM targets
+
+```bash
+rustup target add wasm32-unknown-unknown  # for cargo test / dev builds
+rustup target add wasm32v1-none           # for stellar contract build
+```
+
+### 3. Stellar CLI v25
+
+```bash
+cargo install stellar-cli --version 25
+stellar --version
+```
+
+---
+
+## Building
+
+```bash
+# Build all contracts as optimised WASM artifacts
+make build
+# or directly:
+stellar contract build
+```
+
+---
+
+## Testing
+
+```bash
+# Run all unit and integration tests
+make test
+# or directly:
+cargo test
+```
+
+All tests must pass before opening a PR. Add tests for every new code path — the existing suite in `src/test.rs` and `tests/integration.rs` shows the patterns to follow.
+
+---
+
+## Formatting and Linting
+
+```bash
+# Auto-format all source files
+make fmt
+
+# Check that formatting and compilation are clean (no changes made)
+make check
+```
+
+`make check` must succeed with **zero warnings** before opening a PR. The CI pipeline enforces this automatically.
+
+---
+
+## Code Style Rules
+
+### `no_std` environment
+This contract runs in a `no_std` WASM environment. Do **not** use:
+- `std::string::String` — use `soroban_sdk::String`
+- `std::vec::Vec` — use `soroban_sdk::Vec`
+- Heap allocations outside the Soroban SDK
+- Any crate that requires `std`
+
+### Soroban SDK patterns
+- Authenticate every caller of a state-changing function with `address.require_auth()` or `Self::assert_admin(&env)`.
+- Read storage once per function call; avoid redundant reads.
+- Emit an event for every observable state change.
+- Use `?` for early-return error propagation — never `unwrap()` or `panic!()` in production code paths.
+
+### Input validation
+- Validate all `Bytes` fields against the relevant size constant before use:
+  - `MAX_METADATA_SIZE` (1 024 bytes) for the top-level `metadata` field
+  - `MAX_DESCRIPTION_SIZE` (256 bytes) for per-item and milestone descriptions
+  - `MAX_TRACKING_ID_SIZE` (128 bytes) for shipping tracking IDs
+  - `MAX_EVIDENCE_HASH_SIZE` (128 bytes) for evidence and counter-evidence hashes
+- Use the private `Self::validate_bytes_size(data, max)` helper — it returns `Err(ContractError::MetadataTooLarge)` on violation.
+
+### Error handling
+- Return errors via `Result<T, ContractError>`.
+- Choose the most specific error variant. Never return a generic error when a specific one exists.
+- Add a doc-comment to every new error variant explaining when it fires.
+
+---
+
+## Error Code Conventions
+
+Error discriminants are part of the **on-chain ABI** and are stored in transaction results. Once an error code is assigned it **must never be renumbered** — doing so is a breaking change for all clients.
+
+Rules:
+1. New errors go in an existing numeric gap (e.g., code 12 is currently free) **or** at the end of a related block.
+2. Document every new variant with a Rust doc-comment.
+3. Update `docs/error-codes.md` and `sdk/error-codes.ts` when adding new codes so frontends can display human-readable messages.
+
+---
+
+## Branching and PR Workflow
+
+1. Fork the repository and create a feature branch:
+   ```
+   git checkout -b feat/your-feature-name
+   ```
+2. Make your changes and ensure `make check` and `make test` pass.
+3. Open a Pull Request against the `main` branch.
+4. Link related issues in the PR description using GitHub closing keywords:
+   ```
+   Closes #123
+   Resolves #456
+   ```
+5. The maintainer will review and may request changes before merging.
+
+### Branch naming conventions
+
+| Prefix | When to use |
+|--------|-------------|
+| `feat/` | New functionality |
+| `fix/` | Bug fix |
+| `refactor/` | Code restructuring with no behaviour change |
+| `docs/` | Documentation only |
+| `test/` | Test additions or fixes |
+| `chore/` | Tooling, CI, dependency updates |
+
+---
+
+## Security Checklist
+
+Before submitting a PR that touches core logic, verify:
+
+- [ ] Every public state-changing function calls `require_auth()` or `assert_admin()`.
+- [ ] All `Bytes` inputs are validated against the appropriate size constant.
+- [ ] No `unwrap()` or `panic!()` in non-test code.
+- [ ] No unbounded loops over user-supplied data.
+- [ ] Storage entries that should expire set an appropriate TTL or rely on `bump_escrow`.
+- [ ] New error variants have doc-comments and are added to `docs/error-codes.md`.
+- [ ] `make check` passes with zero warnings.
+- [ ] `make test` passes with no failures.
+
+---
+
+## Helpful References
+
+- [Soroban SDK docs](https://docs.rs/soroban-sdk)
+- [Stellar Developer Docs](https://developers.stellar.org/docs/smart-contracts)
+- [Contract error codes](docs/error-codes.md)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "marketx"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "arbitrary",
  "proptest",

--- a/contracts/marketx/Cargo.toml
+++ b/contracts/marketx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marketx"
-version = "0.0.0"
+version = "1.0.0"
 edition = "2021"
 publish = false
 

--- a/contracts/marketx/src/lib.rs
+++ b/contracts/marketx/src/lib.rs
@@ -98,6 +98,11 @@ use soroban_sdk::xdr::ToXdr;
 
 pub use errors::ContractError;
 pub use types::{
+    CONTRACT_VERSION,
+    ContractVersion,
+    MAX_DESCRIPTION_SIZE,
+    MAX_TRACKING_ID_SIZE,
+    MAX_EVIDENCE_HASH_SIZE,
     AdminTransferredEvent,
     AppealFiledEvent,
     AppealRecord,
@@ -237,6 +242,13 @@ impl Contract {
             if data.len() > MAX_METADATA_SIZE {
                 return Err(ContractError::MetadataTooLarge);
             }
+        }
+        Ok(())
+    }
+
+    fn validate_bytes_size(data: &Bytes, max: u32) -> Result<(), ContractError> {
+        if data.len() > max {
+            return Err(ContractError::MetadataTooLarge);
         }
         Ok(())
     }
@@ -465,6 +477,10 @@ impl Contract {
     ) -> Result<u64, ContractError> {
         Self::validate_metadata(&metadata)?;
 
+        if let Some(ref tid) = tracking_id {
+            Self::validate_bytes_size(tid, MAX_TRACKING_ID_SIZE)?;
+        }
+
         if amount <= 0 {
             return Err(ContractError::InvalidEscrowAmount);
         }
@@ -483,6 +499,13 @@ impl Contract {
                 let items_sum: i128 = items_vec.iter().map(|item| item.amount).sum();
                 if items_sum != amount {
                     return Err(ContractError::ItemAmountInvalid);
+                }
+
+                // Validate per-item descriptions
+                for item in items_vec.iter() {
+                    if let Some(ref desc) = item.description {
+                        Self::validate_bytes_size(desc, MAX_DESCRIPTION_SIZE)?;
+                    }
                 }
 
                 items_vec
@@ -792,6 +815,16 @@ impl Contract {
             evidence_window_ledgers: DEFAULT_EVIDENCE_WINDOW_LEDGERS,
             appeal_window_ledgers: APPEAL_WINDOW_LEDGERS,
             max_ttl: env.storage().max_ttl(),
+        }
+    }
+
+    /// Return the semantic version of this contract deployment.
+    /// Callers can compare against `CONTRACT_VERSION` to verify compatibility.
+    pub fn get_version(_env: Env) -> ContractVersion {
+        ContractVersion {
+            major: 1,
+            minor: 0,
+            patch: 0,
         }
     }
 
@@ -1321,6 +1354,8 @@ impl Contract {
     ) -> Result<u64, ContractError> {
         Self::assert_not_paused(&env)?;
         initiator.require_auth();
+
+        Self::validate_bytes_size(&evidence_hash, MAX_EVIDENCE_HASH_SIZE)?;
 
         let mut escrow: Escrow = env
             .storage()
@@ -1860,6 +1895,8 @@ impl Contract {
     ) -> Result<(), ContractError> {
         Self::assert_not_paused(&env)?;
         party.require_auth();
+
+        Self::validate_bytes_size(&evidence_hash, MAX_EVIDENCE_HASH_SIZE)?;
 
         let escrow: Escrow = env
             .storage()
@@ -2612,6 +2649,11 @@ impl Contract {
         let milestone_sum: i128 = milestones.iter().map(|m| m.amount).sum();
         if milestone_sum != amount {
             return Err(ContractError::ItemAmountInvalid);
+        }
+
+        // Validate milestone descriptions
+        for m in milestones.iter() {
+            Self::validate_bytes_size(&m.description, MAX_DESCRIPTION_SIZE)?;
         }
 
         let escrow_id = Self::create_escrow_internal(

--- a/contracts/marketx/src/types.rs
+++ b/contracts/marketx/src/types.rs
@@ -3,6 +3,18 @@ use soroban_sdk::{contractevent, contracttype, Address, Bytes, BytesN, Vec};
 #[cfg(test)]
 use soroban_sdk::Env;
 
+/// Semantic version of this contract. Matches the `version` field in `Cargo.toml`.
+pub const CONTRACT_VERSION: &str = "1.0.0";
+
+/// On-chain version information returned by `get_version()`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
 /// Returns the contract address for the native XLM token (Stellar Asset Contract).
 ///
 /// # Example
@@ -80,6 +92,15 @@ pub enum DataKey {
 }
 
 pub const MAX_METADATA_SIZE: u32 = 1024;
+
+/// Maximum size for per-item and milestone description fields (bytes).
+pub const MAX_DESCRIPTION_SIZE: u32 = 256;
+
+/// Maximum size for a shipping tracking ID (bytes).
+pub const MAX_TRACKING_ID_SIZE: u32 = 128;
+
+/// Maximum size for an evidence hash (e.g., IPFS CID) submitted during disputes (bytes).
+pub const MAX_EVIDENCE_HASH_SIZE: u32 = 128;
 
 /// Maximum number of items per escrow
 pub const MAX_ITEMS_PER_ESCROW: u32 = 50;

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,165 @@
+# MarketX Contract — Error Code Reference
+
+Every public function that can fail returns a `ContractError`. On-chain, these are represented as `u32` discriminants. This document maps each code to a human-readable message so that frontends and integrators can display meaningful feedback.
+
+> **Important for maintainers:** Error discriminants are part of the on-chain ABI. Never renumber an existing code — doing so is a breaking change. Add new codes in numeric gaps or at the end of the relevant group. See `CONTRIBUTING.md` for the full convention.
+
+---
+
+## Access Control (1–4)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 1 | `NotAdmin` | Only the contract admin can perform this action. | — |
+| 2 | `Unauthorized` | You are not authorized to perform this operation. | Ensure you are a party to the escrow (buyer, seller, or arbiter). |
+| 3 | `NotProposedAdmin` | This address is not the proposed new admin. | — |
+| 4 | `NotOracle` | Only the registered oracle may call this function. | — |
+
+---
+
+## Escrow State (10–13)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 10 | `EscrowNotFound` | Escrow not found. | Check that the escrow ID is correct. |
+| 11 | `InvalidEscrowState` | The escrow is in the wrong state for this action. | Check the escrow status before calling. |
+| 13 | `InvalidEscrowAmount` | Invalid escrow amount — must be greater than zero. | — |
+
+---
+
+## Circuit Breaker (31)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 31 | `ContractPaused` | The contract is currently paused. Please try again later. | Wait for the admin to unpause the contract. |
+
+---
+
+## Overflow Protection (40)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 40 | `EscrowIdOverflow` | The maximum number of escrows has been reached. | — |
+
+---
+
+## Fee Configuration (50)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 50 | `InvalidFeeConfig` | The fee configuration is invalid. | Ensure fee values are within allowed bounds. |
+
+---
+
+## Input Validation (60)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 60 | `MetadataTooLarge` | Metadata or description field exceeds the maximum allowed size. | Reduce the size of the metadata, description, tracking ID, or evidence hash. |
+
+Size limits enforced by error 60:
+
+| Field | Limit |
+|-------|-------|
+| `metadata` | 1 024 bytes |
+| Per-item `description` | 256 bytes |
+| Milestone `description` | 256 bytes |
+| `tracking_id` | 128 bytes |
+| `evidence_hash` | 128 bytes |
+
+---
+
+## Duplicate Prevention (70)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 70 | `DuplicateEscrow` | An escrow with the same buyer, seller, and metadata already exists. | Change the metadata to create a distinct escrow. |
+
+---
+
+## Items (80–83)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 80 | `ItemNotFound` | Item index not found in this escrow. | Check the item index. |
+| 81 | `ItemAlreadyReleased` | This item has already been released. | — |
+| 82 | `TooManyItems` | Too many items per escrow (maximum: 50). | Split the escrow into multiple escrows. |
+| 83 | `ItemAmountInvalid` | Item amounts do not sum to the total escrow amount. | Ensure all item amounts add up to the escrow total. |
+
+---
+
+## Expiry and Funding (90–91)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 90 | `EscrowNotExpired` | The escrow has not yet expired. | Wait for the unfunded expiry window (~7 days) to pass. |
+| 91 | `EscrowAlreadyFunded` | The escrow has already been funded. | — |
+
+---
+
+## Milestones (100–101)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 100 | `MilestoneNotFound` | Milestone index not found. | Check the milestone index. |
+| 101 | `MilestoneAlreadyCompleted` | This milestone has already been completed. | — |
+
+---
+
+## Time-Lock (110–111)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 110 | `TimeLockNotReached` | The time-lock release ledger has not been reached yet. | Wait until the configured release ledger. |
+| 111 | `TimeLockNotEnabled` | No time-lock is configured for this escrow. | — |
+
+---
+
+## Group Buy (120–123)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 120 | `GroupBuyNotFunded` | The group buy target amount has not been reached yet. | — |
+| 121 | `GroupBuyAlreadyFunded` | The group buy has already been fully funded. | — |
+| 122 | `GroupBuyDeadlinePassed` | The group buy funding deadline has passed. | — |
+| 123 | `InvalidGroupBuyAmount` | Invalid group buy contribution amount. | — |
+
+---
+
+## Dispute Resolution — Arbiter Staking (130–132)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 130 | `ArbiterStakeInsufficient` | The arbiter stake is below the required minimum. | Increase the stake to meet the minimum. |
+| 131 | `ArbiterAlreadyStaked` | The arbiter already has an active stake on this escrow. | — |
+| 132 | `ArbiterMismatch` | The caller is not the registered arbiter for this escrow. | — |
+
+---
+
+## Dispute Resolution — Evidence Window (140–142)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 140 | `EvidenceWindowExpired` | The evidence submission window has closed. No further submissions are accepted. | — |
+| 141 | `EvidenceWindowNotExpired` | The evidence window has not yet expired. | Wait for the window to expire before forcing closure. |
+| 142 | `NoEvidenceWindow` | No evidence window is open for this escrow. | — |
+
+---
+
+## Dispute Resolution — Appeals (150–153)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 150 | `AppealAlreadyFiled` | An appeal has already been filed for this escrow. | — |
+| 151 | `AppealNotFound` | No appeal record exists for this escrow. | — |
+| 152 | `AppealWindowClosed` | The appeal window has closed. | — |
+| 153 | `AppealAlreadyResolved` | The appeal has already been resolved. | — |
+
+---
+
+## Updating this document
+
+When adding a new `ContractError` variant:
+1. Add it to the appropriate section above (or create a new section).
+2. Update `sdk/error-codes.ts` to add the corresponding TypeScript entry.
+3. Keep codes in ascending numeric order within each section.

--- a/sdk/error-codes.ts
+++ b/sdk/error-codes.ts
@@ -1,0 +1,251 @@
+/**
+ * MarketX Contract — Error Code Mapping
+ *
+ * Maps every `ContractError` discriminant to a user-friendly message and an
+ * optional recovery hint. Import this file into any frontend or SDK that
+ * interacts with the MarketX escrow contract.
+ *
+ * Usage:
+ *   import { getContractError, MARKETX_ERRORS } from './error-codes';
+ *
+ *   const err = getContractError(10);
+ *   // { code: 'EscrowNotFound', message: 'Escrow not found.', recovery: 'Check that the escrow ID is correct.' }
+ */
+
+export interface ContractErrorInfo {
+  /** Rust variant name for debugging / logging. */
+  code: string;
+  /** Human-readable sentence suitable for display in a UI. */
+  message: string;
+  /** Optional guidance the UI can show to help the user recover. Empty string when there is nothing actionable. */
+  recovery: string;
+}
+
+export const MARKETX_ERRORS: Readonly<Record<number, ContractErrorInfo>> = {
+  // ── Access Control ────────────────────────────────────────────────────────
+  1: {
+    code: 'NotAdmin',
+    message: 'Only the contract admin can perform this action.',
+    recovery: '',
+  },
+  2: {
+    code: 'Unauthorized',
+    message: 'You are not authorized to perform this operation.',
+    recovery: 'Ensure you are a party to the escrow (buyer, seller, or arbiter).',
+  },
+  3: {
+    code: 'NotProposedAdmin',
+    message: 'This address is not the proposed new admin.',
+    recovery: '',
+  },
+  4: {
+    code: 'NotOracle',
+    message: 'Only the registered oracle may call this function.',
+    recovery: '',
+  },
+
+  // ── Escrow State ──────────────────────────────────────────────────────────
+  10: {
+    code: 'EscrowNotFound',
+    message: 'Escrow not found.',
+    recovery: 'Check that the escrow ID is correct.',
+  },
+  11: {
+    code: 'InvalidEscrowState',
+    message: 'The escrow is in the wrong state for this action.',
+    recovery: 'Check the escrow status before calling.',
+  },
+  13: {
+    code: 'InvalidEscrowAmount',
+    message: 'Invalid escrow amount — must be greater than zero.',
+    recovery: '',
+  },
+
+  // ── Circuit Breaker ───────────────────────────────────────────────────────
+  31: {
+    code: 'ContractPaused',
+    message: 'The contract is currently paused. Please try again later.',
+    recovery: 'Wait for the admin to unpause the contract.',
+  },
+
+  // ── Overflow Protection ───────────────────────────────────────────────────
+  40: {
+    code: 'EscrowIdOverflow',
+    message: 'The maximum number of escrows has been reached.',
+    recovery: '',
+  },
+
+  // ── Fee Configuration ─────────────────────────────────────────────────────
+  50: {
+    code: 'InvalidFeeConfig',
+    message: 'The fee configuration is invalid.',
+    recovery: 'Ensure fee values are within allowed bounds.',
+  },
+
+  // ── Input Validation ──────────────────────────────────────────────────────
+  60: {
+    code: 'MetadataTooLarge',
+    message: 'A metadata or description field exceeds the maximum allowed size.',
+    recovery:
+      'Reduce the size of the metadata, description, tracking ID, or evidence hash. Limits: metadata 1 024 B, descriptions 256 B, tracking ID 128 B, evidence hash 128 B.',
+  },
+
+  // ── Duplicate Prevention ──────────────────────────────────────────────────
+  70: {
+    code: 'DuplicateEscrow',
+    message: 'An escrow with the same buyer, seller, and metadata already exists.',
+    recovery: 'Change the metadata to create a distinct escrow.',
+  },
+
+  // ── Items ─────────────────────────────────────────────────────────────────
+  80: {
+    code: 'ItemNotFound',
+    message: 'Item index not found in this escrow.',
+    recovery: 'Check the item index.',
+  },
+  81: {
+    code: 'ItemAlreadyReleased',
+    message: 'This item has already been released.',
+    recovery: '',
+  },
+  82: {
+    code: 'TooManyItems',
+    message: 'Too many items per escrow (maximum: 50).',
+    recovery: 'Split the escrow into multiple escrows.',
+  },
+  83: {
+    code: 'ItemAmountInvalid',
+    message: 'Item amounts do not sum to the total escrow amount.',
+    recovery: 'Ensure all item amounts add up to the escrow total.',
+  },
+
+  // ── Expiry and Funding ────────────────────────────────────────────────────
+  90: {
+    code: 'EscrowNotExpired',
+    message: 'The escrow has not yet expired.',
+    recovery: 'Wait for the unfunded expiry window (~7 days) to pass.',
+  },
+  91: {
+    code: 'EscrowAlreadyFunded',
+    message: 'The escrow has already been funded.',
+    recovery: '',
+  },
+
+  // ── Milestones ────────────────────────────────────────────────────────────
+  100: {
+    code: 'MilestoneNotFound',
+    message: 'Milestone index not found.',
+    recovery: 'Check the milestone index.',
+  },
+  101: {
+    code: 'MilestoneAlreadyCompleted',
+    message: 'This milestone has already been completed.',
+    recovery: '',
+  },
+
+  // ── Time-Lock ─────────────────────────────────────────────────────────────
+  110: {
+    code: 'TimeLockNotReached',
+    message: 'The time-lock release ledger has not been reached yet.',
+    recovery: 'Wait until the configured release ledger.',
+  },
+  111: {
+    code: 'TimeLockNotEnabled',
+    message: 'No time-lock is configured for this escrow.',
+    recovery: '',
+  },
+
+  // ── Group Buy ─────────────────────────────────────────────────────────────
+  120: {
+    code: 'GroupBuyNotFunded',
+    message: 'The group buy target amount has not been reached yet.',
+    recovery: '',
+  },
+  121: {
+    code: 'GroupBuyAlreadyFunded',
+    message: 'The group buy has already been fully funded.',
+    recovery: '',
+  },
+  122: {
+    code: 'GroupBuyDeadlinePassed',
+    message: 'The group buy funding deadline has passed.',
+    recovery: '',
+  },
+  123: {
+    code: 'InvalidGroupBuyAmount',
+    message: 'Invalid group buy contribution amount.',
+    recovery: '',
+  },
+
+  // ── Dispute Resolution — Arbiter Staking ──────────────────────────────────
+  130: {
+    code: 'ArbiterStakeInsufficient',
+    message: 'The arbiter stake is below the required minimum.',
+    recovery: 'Increase the stake amount to meet the minimum requirement.',
+  },
+  131: {
+    code: 'ArbiterAlreadyStaked',
+    message: 'The arbiter already has an active stake on this escrow.',
+    recovery: '',
+  },
+  132: {
+    code: 'ArbiterMismatch',
+    message: 'The caller is not the registered arbiter for this escrow.',
+    recovery: '',
+  },
+
+  // ── Dispute Resolution — Evidence Window ──────────────────────────────────
+  140: {
+    code: 'EvidenceWindowExpired',
+    message: 'The evidence submission window has closed. No further submissions are accepted.',
+    recovery: '',
+  },
+  141: {
+    code: 'EvidenceWindowNotExpired',
+    message: 'The evidence window has not yet expired.',
+    recovery: 'Wait for the evidence window to expire before forcing closure.',
+  },
+  142: {
+    code: 'NoEvidenceWindow',
+    message: 'No evidence window is open for this escrow.',
+    recovery: '',
+  },
+
+  // ── Dispute Resolution — Appeals ──────────────────────────────────────────
+  150: {
+    code: 'AppealAlreadyFiled',
+    message: 'An appeal has already been filed for this escrow.',
+    recovery: '',
+  },
+  151: {
+    code: 'AppealNotFound',
+    message: 'No appeal record exists for this escrow.',
+    recovery: '',
+  },
+  152: {
+    code: 'AppealWindowClosed',
+    message: 'The appeal window has closed.',
+    recovery: '',
+  },
+  153: {
+    code: 'AppealAlreadyResolved',
+    message: 'The appeal has already been resolved.',
+    recovery: '',
+  },
+} as const;
+
+/**
+ * Look up a contract error by its numeric code.
+ * Returns `undefined` when the code is not recognised.
+ */
+export function getContractError(code: number): ContractErrorInfo | undefined {
+  return MARKETX_ERRORS[code];
+}
+
+/**
+ * Return a display-ready error message for a given code.
+ * Falls back to a generic message when the code is unknown.
+ */
+export function getErrorMessage(code: number): string {
+  return MARKETX_ERRORS[code]?.message ?? `Unknown contract error (code ${code}).`;
+}


### PR DESCRIPTION
## Summary

* **#218 – Semantic Versioning**: Added `ContractVersion` struct, `CONTRACT_VERSION` constant, and
  `get_version()` on-chain function; bumped `Cargo.toml` version to `1.0.0`.
* **#219 – Contribution Guidelines**: Added `CONTRIBUTING.md` covering prerequisites, build/test/format commands,
  `no_std` code style, error code conventions, PR workflow, and security checklist.
* **#220 – Error Code Mapping**: Added `docs/error-codes.md` (human-readable reference) and `sdk/error-codes.ts`
  (TypeScript map with `getContractError` / `getErrorMessage` helpers) for all 35 contract error codes.
* **#221 – Input Sanitization**: Added `MAX_DESCRIPTION_SIZE` (256 B), `MAX_TRACKING_ID_SIZE` (128 B),
  `MAX_EVIDENCE_HASH_SIZE` (128 B) constants and a `validate_bytes_size` helper; enforced at every unbounded
  `Bytes` input: item descriptions, milestone descriptions, tracking IDs, and evidence hashes.

---

## Test plan

* [x] `cargo check` passes with zero new warnings
* [ ] `get_version()` returns `{ major: 1, minor: 0, patch: 0 }` in integration tests
* [ ] Creating an escrow with an item description > 256 bytes returns `MetadataTooLarge`
* [ ] Creating a milestone escrow with a description > 256 bytes returns `MetadataTooLarge`
* [ ] Submitting an evidence hash > 128 bytes returns `MetadataTooLarge`

---

## Closes

Closes #218
Closes #219
Closes #220
Closes #221
