### PR TITLE
 2-Step Admin Transfer Verification

### DIFF
--- a/contracts/marketx/src/errors.rs
+++ b/contracts/marketx/src/errors.rs
@@ -52,4 +52,8 @@ pub enum ContractError {
     AppealWindowClosed = 152,
     /// The appeal has already been resolved (#203).
     AppealAlreadyResolved = 153,
+    /// A governance-controlled feature flag has disabled this operation.
+    FeatureDisabled = 160,
+    /// Invalid admin transfer request (for example, proposing the current admin).
+    InvalidAdminTransfer = 161,
 }

--- a/contracts/marketx/src/lib.rs
+++ b/contracts/marketx/src/lib.rs
@@ -163,6 +163,20 @@ mod test;
 pub struct Contract;
 
 impl Contract {
+    fn disputes_enabled(env: &Env) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::FeatureDisputesEnabled)
+            .unwrap_or(true)
+    }
+
+    fn partial_releases_enabled(env: &Env) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::FeaturePartialReleasesEnabled)
+            .unwrap_or(true)
+    }
+
     fn assert_admin(env: &Env) -> Result<Address, ContractError> {
         let admin = env
             .storage()
@@ -185,6 +199,20 @@ impl Contract {
             return Err(ContractError::ContractPaused);
         }
 
+        Ok(())
+    }
+
+    fn assert_disputes_enabled(env: &Env) -> Result<(), ContractError> {
+        if !Self::disputes_enabled(env) {
+            return Err(ContractError::FeatureDisabled);
+        }
+        Ok(())
+    }
+
+    fn assert_partial_releases_enabled(env: &Env) -> Result<(), ContractError> {
+        if !Self::partial_releases_enabled(env) {
+            return Err(ContractError::FeatureDisabled);
+        }
         Ok(())
     }
 
@@ -446,6 +474,32 @@ impl Contract {
             .persistent()
             .get(&DataKey::Paused)
             .unwrap_or(false)
+    }
+
+    /// Admin-controlled governance toggle for dispute operations.
+    pub fn set_disputes_enabled(env: Env, enabled: bool) -> Result<(), ContractError> {
+        Self::assert_admin(&env)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::FeatureDisputesEnabled, &enabled);
+        Ok(())
+    }
+
+    /// Admin-controlled governance toggle for partial release operations.
+    pub fn set_partial_releases_enabled(env: Env, enabled: bool) -> Result<(), ContractError> {
+        Self::assert_admin(&env)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::FeaturePartialReleasesEnabled, &enabled);
+        Ok(())
+    }
+
+    pub fn is_disputes_enabled(env: Env) -> bool {
+        Self::disputes_enabled(&env)
+    }
+
+    pub fn is_partial_releases_enabled(env: Env) -> bool {
+        Self::partial_releases_enabled(&env)
     }
 
     // =========================
@@ -1122,6 +1176,7 @@ impl Contract {
     }
     pub fn release_partial(env: Env, _escrow_id: u64, _amount: i128) -> Result<(), ContractError> {
         Self::assert_not_paused(&env)?;
+        Self::assert_partial_releases_enabled(&env)?;
         Ok(())
     }
 
@@ -1142,6 +1197,7 @@ impl Contract {
     /// * `ItemAlreadyReleased` - If the item has already been released
     pub fn release_item(env: Env, escrow_id: u64, item_index: u32) -> Result<(), ContractError> {
         Self::assert_not_paused(&env)?;
+        Self::assert_partial_releases_enabled(&env)?;
 
         // 1. Load and validate the escrow exists
         let mut escrow: Escrow = env
@@ -1320,6 +1376,7 @@ impl Contract {
         evidence_hash: Bytes,
     ) -> Result<u64, ContractError> {
         Self::assert_not_paused(&env)?;
+        Self::assert_disputes_enabled(&env)?;
         initiator.require_auth();
 
         let mut escrow: Escrow = env
@@ -1486,6 +1543,7 @@ impl Contract {
     /// `resolution`: 0 = release to seller, 1 = refund to buyer
     pub fn resolve_dispute(env: Env, escrow_id: u64, resolution: u32) -> Result<(), ContractError> {
         Self::assert_not_paused(&env)?;
+        Self::assert_disputes_enabled(&env)?;
 
         let mut escrow: Escrow = env
             .storage()
@@ -1625,6 +1683,7 @@ impl Contract {
         amount: i128,
     ) -> Result<(), ContractError> {
         Self::assert_not_paused(&env)?;
+        Self::assert_disputes_enabled(&env)?;
         arbiter.require_auth();
 
         let escrow: Escrow = env
@@ -1714,6 +1773,7 @@ impl Contract {
     /// - `AppealNotFound` if no resolved-and-overturned appeal exists.
     pub fn slash_arbiter(env: Env, escrow_id: u64) -> Result<(), ContractError> {
         Self::assert_admin(&env)?;
+        Self::assert_disputes_enabled(&env)?;
 
         let appeal: AppealRecord = env
             .storage()
@@ -1799,6 +1859,7 @@ impl Contract {
         window_ledgers: u32,
     ) -> Result<(), ContractError> {
         Self::assert_not_paused(&env)?;
+        Self::assert_disputes_enabled(&env)?;
         caller.require_auth();
 
         let escrow: Escrow = env
@@ -1859,6 +1920,7 @@ impl Contract {
         evidence_hash: Bytes,
     ) -> Result<(), ContractError> {
         Self::assert_not_paused(&env)?;
+        Self::assert_disputes_enabled(&env)?;
         party.require_auth();
 
         let escrow: Escrow = env
@@ -1910,6 +1972,7 @@ impl Contract {
     /// (default in favour of buyer when arbiter is absent).
     pub fn expire_evidence_window(env: Env, escrow_id: u64) -> Result<(), ContractError> {
         Self::assert_not_paused(&env)?;
+        Self::assert_disputes_enabled(&env)?;
 
         let mut window: EvidenceWindow = env
             .storage()
@@ -1977,6 +2040,7 @@ impl Contract {
         ruling_ledger: u32,
     ) -> Result<(), ContractError> {
         Self::assert_not_paused(&env)?;
+        Self::assert_disputes_enabled(&env)?;
         appellant.require_auth();
 
         let escrow: Escrow = env
@@ -2051,6 +2115,7 @@ impl Contract {
         resolution: u32,
     ) -> Result<(), ContractError> {
         Self::assert_not_paused(&env)?;
+        Self::assert_disputes_enabled(&env)?;
         admin.require_auth();
         Self::assert_admin(&env)?;
 
@@ -2206,10 +2271,20 @@ impl Contract {
 
     /// Propose a new admin. The transfer is not complete until the new admin accepts.
     pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), ContractError> {
-        Self::assert_admin(&env)?;
+        let current_admin = Self::assert_admin(&env)?;
+        if new_admin == current_admin {
+            return Err(ContractError::InvalidAdminTransfer);
+        }
         env.storage()
             .persistent()
             .set(&DataKey::ProposedAdmin, &new_admin);
+        Ok(())
+    }
+
+    /// Cancel an in-flight admin transfer proposal.
+    pub fn cancel_admin_transfer(env: Env) -> Result<(), ContractError> {
+        Self::assert_admin(&env)?;
+        env.storage().persistent().remove(&DataKey::ProposedAdmin);
         Ok(())
     }
 
@@ -2246,6 +2321,10 @@ impl Contract {
 
     pub fn get_admin(env: Env) -> Option<Address> {
         env.storage().persistent().get(&DataKey::Admin)
+    }
+
+    pub fn get_proposed_admin(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::ProposedAdmin)
     }
 
     pub fn set_fee_percentage(env: Env, fee_bps: u32) -> Result<(), ContractError> {

--- a/contracts/marketx/src/test.rs
+++ b/contracts/marketx/src/test.rs
@@ -95,6 +95,35 @@ fn admin_rotation_flow() {
 }
 
 #[test]
+fn transfer_admin_rejects_current_admin_address() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &collector, &250, &0, &0);
+
+    let result = client.try_transfer_admin(&admin);
+    assert_eq!(result, Err(Ok(ContractError::InvalidAdminTransfer)));
+}
+
+#[test]
+fn admin_can_cancel_transfer_proposal() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &collector, &250, &0, &0);
+    client.transfer_admin(&new_admin);
+    assert_eq!(client.get_proposed_admin(), Some(new_admin.clone()));
+
+    client.cancel_admin_transfer();
+    assert_eq!(client.get_proposed_admin(), None);
+}
+
+#[test]
 fn accept_admin_fails_if_none_proposed() {
     let (env, client) = setup();
     let admin = Address::generate(&env);
@@ -202,6 +231,43 @@ fn escrow_actions_blocked_when_paused() {
 
     let result = client.try_fund_escrow(&1u64);
     assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+}
+
+#[test]
+fn admin_can_toggle_governance_feature_flags() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &collector, &250, &0, &0);
+
+    assert!(client.is_disputes_enabled());
+    assert!(client.is_partial_releases_enabled());
+
+    client.set_disputes_enabled(&false);
+    client.set_partial_releases_enabled(&false);
+
+    assert!(!client.is_disputes_enabled());
+    assert!(!client.is_partial_releases_enabled());
+}
+
+#[test]
+fn disabled_feature_flags_block_paths() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &collector, &250, &0, &0);
+    client.set_disputes_enabled(&false);
+    client.set_partial_releases_enabled(&false);
+
+    let partial_release = client.try_release_partial(&1u64, &1i128);
+    assert_eq!(partial_release, Err(Ok(ContractError::FeatureDisabled)));
+
+    let resolve_dispute = client.try_resolve_dispute(&999u64, &0u32);
+    assert_eq!(resolve_dispute, Err(Ok(ContractError::FeatureDisabled)));
 }
 
 #[test]
@@ -2274,7 +2340,7 @@ fn test_non_whitelisted_buyer_pays_fee() {
     let escrow_id = client.create_escrow(
         &buyer,
         &seller,
-        &token_id.address(, &None),
+        &token_id.address(),
         &500,
         &None,
         &None,
@@ -2312,7 +2378,17 @@ fn test_non_whitelisted_buyer_pays_fee() {
     let amount: i128 = 10_000;
     xlm_admin.mint(&buyer, &amount);
 
-    let escrow_id = client.create_escrow(&buyer, &seller, &xlm_address, &amount, &None, &None, &None, &None, &None);
+    let escrow_id = client.create_escrow(
+        &buyer,
+        &seller,
+        &xlm_address,
+        &amount,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
     client.fund_escrow(&escrow_id);
     client.release_escrow(&escrow_id);
 
@@ -2505,13 +2581,13 @@ fn test_initialize_rejects_zero_admin() {
     let env = Env::default();
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
-    
+
     let collector = Address::generate(&env);
     // Create a zero address by creating all-zero bytes
     let zero_admin = Address::from_contract_id(&env, &BytesN::from_array(&env, &[0u8; 32]));
-    
+
     env.mock_all_auths();
-    
+
     // Initialize with zero admin should fail
     let result = client.try_initialize(&zero_admin, &collector, &250, &0, &0);
     assert_eq!(result, Err(Ok(ContractError::ZeroAddress)));
@@ -2522,13 +2598,13 @@ fn test_initialize_rejects_zero_fee_collector() {
     let env = Env::default();
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     // Create a zero address
     let zero_collector = Address::from_contract_id(&env, &BytesN::from_array(&env, &[0u8; 32]));
-    
+
     env.mock_all_auths();
-    
+
     // Initialize with zero fee_collector should fail
     let result = client.try_initialize(&admin, &zero_collector, &250, &0, &0);
     assert_eq!(result, Err(Ok(ContractError::ZeroAddress)));
@@ -2540,12 +2616,12 @@ fn test_create_escrow_rejects_zero_buyer() {
     let admin = Address::generate(&env);
     let seller = Address::generate(&env);
     let token = Address::generate(&env);
-    
+
     let zero_buyer = Address::from_contract_id(&env, &BytesN::from_array(&env, &[0u8; 32]));
-    
+
     env.mock_all_auths();
     client.initialize(&admin, &admin, &250, &0, &0);
-    
+
     // Create escrow with zero buyer should fail
     let result = client.try_create_escrow(&zero_buyer, &seller, &token, &1000, &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::ZeroAddress)));
@@ -2557,12 +2633,12 @@ fn test_create_escrow_rejects_zero_seller() {
     let admin = Address::generate(&env);
     let buyer = Address::generate(&env);
     let token = Address::generate(&env);
-    
+
     let zero_seller = Address::from_contract_id(&env, &BytesN::from_array(&env, &[0u8; 32]));
-    
+
     env.mock_all_auths();
     client.initialize(&admin, &admin, &250, &0, &0);
-    
+
     // Create escrow with zero seller should fail
     let result = client.try_create_escrow(&buyer, &zero_seller, &token, &1000, &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::ZeroAddress)));
@@ -2574,12 +2650,12 @@ fn test_create_escrow_rejects_zero_token() {
     let admin = Address::generate(&env);
     let buyer = Address::generate(&env);
     let seller = Address::generate(&env);
-    
+
     let zero_token = Address::from_contract_id(&env, &BytesN::from_array(&env, &[0u8; 32]));
-    
+
     env.mock_all_auths();
     client.initialize(&admin, &admin, &250, &0, &0);
-    
+
     // Create escrow with zero token should fail
     let result = client.try_create_escrow(&buyer, &seller, &zero_token, &1000, &None, &None, &None);
     assert_eq!(result, Err(Ok(ContractError::ZeroAddress)));
@@ -2592,14 +2668,22 @@ fn test_create_escrow_rejects_zero_arbiter() {
     let buyer = Address::generate(&env);
     let seller = Address::generate(&env);
     let token = Address::generate(&env);
-    
+
     let zero_arbiter = Address::from_contract_id(&env, &BytesN::from_array(&env, &[0u8; 32]));
-    
+
     env.mock_all_auths();
     client.initialize(&admin, &admin, &250, &0, &0);
-    
+
     // Create escrow with zero arbiter should fail
-    let result = client.try_create_escrow(&buyer, &seller, &token, &1000, &None, &Some(zero_arbiter), &None);
+    let result = client.try_create_escrow(
+        &buyer,
+        &seller,
+        &token,
+        &1000,
+        &None,
+        &Some(zero_arbiter),
+        &None,
+    );
     assert_eq!(result, Err(Ok(ContractError::ZeroAddress)));
 }
 
@@ -2609,12 +2693,12 @@ fn test_create_bulk_escrows_rejects_zero_buyer() {
     let admin = Address::generate(&env);
     let seller = Address::generate(&env);
     let token = Address::generate(&env);
-    
+
     let zero_buyer = Address::from_contract_id(&env, &BytesN::from_array(&env, &[0u8; 32]));
-    
+
     env.mock_all_auths();
     client.initialize(&admin, &admin, &250, &0, &0);
-    
+
     let mut requests = Vec::new(&env);
     requests.push_back(BulkEscrowRequest {
         seller: seller.clone(),
@@ -2623,7 +2707,7 @@ fn test_create_bulk_escrows_rejects_zero_buyer() {
         arbiter: None,
         items: None,
     });
-    
+
     // Create bulk escrows with zero buyer should fail
     let result = client.try_create_bulk_escrows(&zero_buyer, &token, &requests);
     assert_eq!(result, Err(Ok(ContractError::ZeroAddress)));
@@ -2636,12 +2720,14 @@ fn test_create_escrow_with_valid_addresses_succeeds() {
     let buyer = Address::generate(&env);
     let seller = Address::generate(&env);
     let token = Address::generate(&env);
-    
+
     env.mock_all_auths();
     client.initialize(&admin, &admin, &250, &0, &0).unwrap();
-    
+
     // Create escrow with valid addresses should succeed
-    let escrow_id = client.create_escrow(&buyer, &seller, &token, &1000, &None, &None, &None).unwrap();
+    let escrow_id = client
+        .create_escrow(&buyer, &seller, &token, &1000, &None, &None, &None)
+        .unwrap();
     assert!(escrow_id > 0);
 }
 

--- a/contracts/marketx/src/types.rs
+++ b/contracts/marketx/src/types.rs
@@ -77,6 +77,10 @@ pub enum DataKey {
     Appeal(u64),
     /// Cumulative on-chain reputation for an arbiter address (#204).
     ArbiterReputation(Address),
+    /// Governance feature flag: enable/disable dispute lifecycle.
+    FeatureDisputesEnabled,
+    /// Governance feature flag: enable/disable partial releases (`release_item`/`release_partial`).
+    FeaturePartialReleasesEnabled,
 }
 
 pub const MAX_METADATA_SIZE: u32 = 1024;


### PR DESCRIPTION
close #214 


Description
Implemented a safer, two-step admin transfer mechanism alongside feature-flag controls for dispute and partial-release functionality.

Added persistent governance flags (FeatureDisputesEnabled, FeaturePartialReleasesEnabled) with corresponding getters and setters: set_disputes_enabled, set_partial_releases_enabled, is_disputes_enabled, and is_partial_releases_enabled.

Introduced new error types (FeatureDisabled, InvalidAdminTransfer) and helper accessors (disputes_enabled, partial_releases_enabled) with guard assertions (assert_disputes_enabled, assert_partial_releases_enabled) to enforce controlled execution paths.


Testing
Successfully ran cargo fmt
Attempted cargo test, but execution was blocked by pre-existing repository issues (e.g., signature mismatches and outdated test expectations) unrelated to this change
Added targeted unit tests in contracts/marketx/src/test.rs covering:
Rejection of self-proposed admin transfers
Cancellation of pending admin proposals
Feature flag toggling behavior
Enforcement of disabled feature restrictions