### PR TITLE
fix: require challenge window + buyer veto before oracle-triggered re…

### DIFF
--- a/contracts/marketx/src/errors.rs
+++ b/contracts/marketx/src/errors.rs
@@ -82,4 +82,10 @@ pub enum ContractError {
     MigrationStorageError = 173,
     /// Migration failed: invalid migration target version.
     MigrationInvalidTargetVersion = 174,
+    /// Oracle already has an unresolved pending release recorded for this escrow (#244).
+    OracleReleasePending = 175,
+    /// No pending oracle release exists for this escrow (#244).
+    NoPendingOracleRelease = 176,
+    /// The oracle challenge window has not yet elapsed (#244).
+    OracleChallengeWindowOpen = 177,
 }

--- a/contracts/marketx/src/lib.rs
+++ b/contracts/marketx/src/lib.rs
@@ -112,12 +112,13 @@ pub use types::{
     FeeCollectorRotatedEvent, FeeExemptionEvent, FeesWithdrawnEvent, FundsReleasedEvent,
     GlobalDisputeAnalytics, GroupBuy, GroupBuyCompletedEvent, GroupBuyFundedEvent,
     MediationOpenedEvent, MediationPhase, MediationProposedEvent, MediationSettledEvent,
-    MetadataVisibility, Milestone, MilestoneCompletedEvent, RefundHistoryEntry, RefundReason,
-    RefundRequest, RefundRequestedEvent, RefundStatus, StatusChangeEvent, StorageRentEstimate,
-    TimeLock, TimeLockReleasedEvent, TokenCircuitBreakerEvent, APPEAL_WINDOW_LEDGERS,
-    CONTRACT_VERSION, CURRENT_SCHEMA_VERSION, DEFAULT_ARBITER_QUORUM_PERCENTAGE,
-    DEFAULT_EVIDENCE_WINDOW_LEDGERS, DEFAULT_MAX_ARBITERS_PER_ESCROW,
-    DEFAULT_MEDIATION_WINDOW_LEDGERS, DEFAULT_MIN_ARBITERS_REQUIRED, MAX_DESCRIPTION_SIZE,
+    MetadataVisibility, Milestone, MilestoneCompletedEvent, PendingOracleRelease,
+    RefundHistoryEntry, RefundReason, RefundRequest, RefundRequestedEvent, RefundStatus,
+    StatusChangeEvent, StorageRentEstimate, TimeLock, TimeLockReleasedEvent,
+    TokenCircuitBreakerEvent, APPEAL_WINDOW_LEDGERS, CONTRACT_VERSION, CURRENT_SCHEMA_VERSION,
+    DEFAULT_ARBITER_QUORUM_PERCENTAGE, DEFAULT_EVIDENCE_WINDOW_LEDGERS,
+    DEFAULT_MAX_ARBITERS_PER_ESCROW, DEFAULT_MEDIATION_WINDOW_LEDGERS,
+    DEFAULT_MIN_ARBITERS_REQUIRED, DEFAULT_ORACLE_CHALLENGE_WINDOW_LEDGERS, MAX_DESCRIPTION_SIZE,
     MAX_EVIDENCE_HASH_SIZE, MAX_ITEMS_PER_ESCROW, MAX_METADATA_SIZE, MAX_TRACKING_ID_SIZE,
     UNFUNDED_EXPIRY_LEDGERS,
 };
@@ -1102,6 +1103,15 @@ impl Contract {
         env.storage().persistent().get(&DataKey::Oracle)
     }
 
+    /// Record oracle intent to release an escrow's funds (#244).
+    ///
+    /// A single oracle attestation no longer moves funds directly. This only
+    /// records a `PendingOracleRelease`; the buyer has
+    /// `DEFAULT_ORACLE_CHALLENGE_WINDOW_LEDGERS` to raise a dispute via
+    /// `refund_escrow` (which moves the escrow to `Disputed`) before anyone
+    /// may call `execute_oracle_release` to finalize the transfer. If the
+    /// buyer disputes in time, the pending release is voided instead of
+    /// executed — the oracle alone can no longer drain the escrow.
     pub fn verify_delivery(env: Env, escrow_id: u64) -> Result<(), ContractError> {
         Self::assert_not_paused(&env)?;
 
@@ -1113,7 +1123,7 @@ impl Contract {
 
         oracle.require_auth();
 
-        let mut escrow: Escrow = env
+        let escrow: Escrow = env
             .storage()
             .persistent()
             .get(&DataKey::Escrow(escrow_id))
@@ -1123,19 +1133,87 @@ impl Contract {
             return Err(ContractError::InvalidEscrowState);
         }
 
-        let _tracking_id = escrow
+        let tracking_id = escrow
             .tracking_id
             .clone()
             .ok_or(ContractError::Unauthorized)?;
 
-        // Oracle verified delivery, release funds
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::PendingOracleRelease(escrow_id))
+        {
+            return Err(ContractError::OracleReleasePending);
+        }
+
+        let now = env.ledger().sequence();
+        let release_at = now + DEFAULT_ORACLE_CHALLENGE_WINDOW_LEDGERS;
+
+        let pending = PendingOracleRelease {
+            escrow_id,
+            oracle,
+            verified_at: now,
+            release_at,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::PendingOracleRelease(escrow_id), &pending);
+
+        DeliveryVerifiedEvent {
+            escrow_id,
+            tracking_id,
+            release_at,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Read the pending oracle release recorded for an escrow, if any (#244).
+    pub fn get_pending_oracle_release(env: Env, escrow_id: u64) -> Option<PendingOracleRelease> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PendingOracleRelease(escrow_id))
+    }
+
+    /// Finalize an oracle-triggered release once its challenge window has elapsed (#244).
+    ///
+    /// Permissionless — anyone may call this to execute a verified delivery
+    /// once `release_at` has passed. Fails (and voids the pending release)
+    /// if the buyer disputed the escrow in the meantime, since the escrow
+    /// will no longer be `Pending`/`Funded`.
+    pub fn execute_oracle_release(env: Env, escrow_id: u64) -> Result<(), ContractError> {
+        Self::assert_not_paused(&env)?;
+
+        let pending: PendingOracleRelease = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingOracleRelease(escrow_id))
+            .ok_or(ContractError::NoPendingOracleRelease)?;
+
+        let now = env.ledger().sequence();
+        if now < pending.release_at {
+            return Err(ContractError::OracleChallengeWindowOpen);
+        }
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .ok_or(ContractError::EscrowNotFound)?;
+
+        // The buyer may have raised a dispute (or otherwise moved the escrow
+        // out of Pending/Funded) during the challenge window. In that case
+        // the oracle's release intent is void — the dispute flow now owns
+        // this escrow's outcome, and this call permanently fails (the escrow
+        // can never return to Pending/Funded from a terminal or disputed
+        // state, so this pending release can never execute).
+        if escrow.status != EscrowStatus::Pending && escrow.status != EscrowStatus::Funded {
+            return Err(ContractError::InvalidEscrowState);
+        }
+
         let from_status = escrow.status.clone();
-
-        // Use Oracle as actor for status change
-        let actor = oracle.clone();
-
-        // Core release logic (duplicated from release_escrow for now to avoid complex refactor in this turn, or I can refactor it)
-        // Actually, let's try to keep it simple.
+        let actor = pending.oracle.clone();
 
         let mut fee_bps: u32 = env
             .storage()
@@ -1208,6 +1286,9 @@ impl Contract {
         env.storage()
             .persistent()
             .set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage()
+            .persistent()
+            .remove(&DataKey::PendingOracleRelease(escrow_id));
 
         FundsReleasedEvent {
             escrow_id,

--- a/contracts/marketx/src/test.rs
+++ b/contracts/marketx/src/test.rs
@@ -2476,8 +2476,27 @@ fn test_oracle_verified_delivery_release() {
     client.fund_escrow(&escrow_id);
     assert_eq!(token.balance(&client.address), amount);
 
-    // Call verify_delivery as oracle
+    // Oracle verifies delivery — this only records intent, funds stay put.
     client.verify_delivery(&escrow_id);
+    assert_eq!(token.balance(&seller), 0);
+    assert_eq!(token.balance(&client.address), amount);
+
+    let escrow = client.get_escrow(&escrow_id).unwrap();
+    assert_eq!(escrow.status, crate::types::EscrowStatus::Funded);
+
+    let pending = client.get_pending_oracle_release(&escrow_id).unwrap();
+    assert_eq!(pending.oracle, oracle);
+
+    // Executing before the challenge window elapses is rejected.
+    assert_eq!(
+        client.try_execute_oracle_release(&escrow_id),
+        Err(Ok(ContractError::OracleChallengeWindowOpen))
+    );
+
+    // Advance past the challenge window with no dispute raised.
+    env.ledger()
+        .with_mut(|l| l.sequence_number = pending.release_at + 1);
+    client.execute_oracle_release(&escrow_id);
 
     // Verify funds released to seller
     assert_eq!(token.balance(&seller), amount);
@@ -2485,6 +2504,113 @@ fn test_oracle_verified_delivery_release() {
 
     let escrow = client.get_escrow(&escrow_id).unwrap();
     assert_eq!(escrow.status, crate::types::EscrowStatus::Released);
+    assert!(client.get_pending_oracle_release(&escrow_id).is_none());
+}
+
+#[test]
+fn test_oracle_release_blocked_by_buyer_dispute() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let oracle = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id.address());
+    let token = soroban_sdk::token::Client::new(&env, &token_id.address());
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0, &0, &0);
+    client.set_oracle(&oracle);
+
+    let tracking_id = Bytes::from_slice(&env, b"SHIP-99999");
+    let amount = 1000;
+    token_admin.mint(&buyer, &amount);
+
+    let escrow_id = client.create_escrow(
+        &buyer,
+        &seller,
+        &token_id.address(),
+        &amount,
+        &None,
+        &None,
+        &None,
+        &Some(tracking_id.clone()),
+    );
+
+    client.fund_escrow(&escrow_id);
+
+    // Oracle claims delivery is verified — but it's compromised/wrong.
+    client.verify_delivery(&escrow_id);
+    let pending = client.get_pending_oracle_release(&escrow_id).unwrap();
+
+    // Buyer raises a dispute within the challenge window.
+    client.refund_escrow(
+        &escrow_id,
+        &buyer,
+        &amount,
+        &crate::types::RefundReason::ProductNotReceived,
+        &Bytes::from_slice(&env, b"evidence"),
+    );
+    let escrow = client.get_escrow(&escrow_id).unwrap();
+    assert_eq!(escrow.status, crate::types::EscrowStatus::Disputed);
+
+    // Advance past the challenge window; the oracle release must not proceed.
+    env.ledger()
+        .with_mut(|l| l.sequence_number = pending.release_at + 1);
+    assert_eq!(
+        client.try_execute_oracle_release(&escrow_id),
+        Err(Ok(ContractError::InvalidEscrowState))
+    );
+
+    // Funds remain in the contract — no drain occurred.
+    assert_eq!(token.balance(&seller), 0);
+    assert_eq!(token.balance(&client.address), amount);
+
+    // The stale pending release can never execute again: the escrow is
+    // permanently out of Pending/Funded once disputed.
+    assert_eq!(
+        client.try_execute_oracle_release(&escrow_id),
+        Err(Ok(ContractError::InvalidEscrowState))
+    );
+}
+
+#[test]
+fn test_verify_delivery_rejects_duplicate_pending_release() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let oracle = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id.address());
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0, &0, &0);
+    client.set_oracle(&oracle);
+
+    let amount = 1000;
+    token_admin.mint(&buyer, &amount);
+
+    let escrow_id = client.create_escrow(
+        &buyer,
+        &seller,
+        &token_id.address(),
+        &amount,
+        &None,
+        &None,
+        &None,
+        &Some(Bytes::from_slice(&env, b"SHIP-DUP")),
+    );
+
+    client.fund_escrow(&escrow_id);
+    client.verify_delivery(&escrow_id);
+
+    assert_eq!(
+        client.try_verify_delivery(&escrow_id),
+        Err(Ok(ContractError::OracleReleasePending))
+    );
 }
 
 #[test]

--- a/contracts/marketx/src/types.rs
+++ b/contracts/marketx/src/types.rs
@@ -122,6 +122,8 @@ pub enum DataKey {
     ArbiterVote(u64, Address),
     /// Voting record for a disputed escrow (tracks votes for release/refund).
     DisputeVoting(u64),
+    /// Pending oracle-triggered release awaiting its challenge window (#244).
+    PendingOracleRelease(u64),
 }
 
 pub const MAX_METADATA_SIZE: u32 = 1024;
@@ -258,6 +260,34 @@ pub struct DeliveryVerifiedEvent {
     #[topic]
     pub escrow_id: u64,
     pub tracking_id: Bytes,
+    /// Ledger after which `execute_oracle_release` may finalize the transfer.
+    pub release_at: u32,
+}
+
+// ─── Issue #244: Oracle Release Challenge Window ─────────────────────────────
+
+/// Default oracle challenge window length in ledgers (~24 hours at 5 s/ledger).
+///
+/// A single oracle attestation is not enough to move funds on its own:
+/// `verify_delivery` only records intent to release. The buyer has this many
+/// ledgers to raise a dispute via `refund_escrow` before `execute_oracle_release`
+/// is allowed to finalize the transfer.
+pub const DEFAULT_ORACLE_CHALLENGE_WINDOW_LEDGERS: u32 = 17_280;
+
+/// A pending oracle-triggered release awaiting its challenge window (#244).
+///
+/// Recorded by `verify_delivery` and consumed by `execute_oracle_release`.
+/// If the buyer disputes the escrow (moving it out of `Pending`/`Funded`)
+/// before `release_at`, the pending release is voided instead of executed.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingOracleRelease {
+    pub escrow_id: u64,
+    pub oracle: Address,
+    /// Ledger at which the oracle verified delivery.
+    pub verified_at: u32,
+    /// Ledger after which the release may be executed.
+    pub release_at: u32,
 }
 
 #[contractevent(topics = ["fee_collected"], data_format = "vec")]

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -157,6 +157,16 @@ Size limits enforced by error 60:
 
 ---
 
+## Oracle Release Challenge Window (175–177)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 175 | `OracleReleasePending` | The oracle already recorded a pending release for this escrow. | Wait for `execute_oracle_release` or for the existing pending release to resolve. |
+| 176 | `NoPendingOracleRelease` | No pending oracle release exists for this escrow. | Call `verify_delivery` first. |
+| 177 | `OracleChallengeWindowOpen` | The oracle challenge window has not yet elapsed. | Wait until the recorded `release_at` ledger before retrying. |
+
+---
+
 ## Updating this document
 
 When adding a new `ContractError` variant:

--- a/sdk/error-codes.ts
+++ b/sdk/error-codes.ts
@@ -307,6 +307,22 @@ export const MARKETX_ERRORS: Readonly<Record<number, ContractErrorInfo>> = {
     message: 'Migration failed: invalid migration target version.',
     recovery: '',
   },
+  // ── Oracle Release Challenge Window ─────────────────────────────────────────
+  175: {
+    code: 'OracleReleasePending',
+    message: 'The oracle already recorded a pending release for this escrow.',
+    recovery: 'Wait for execute_oracle_release or for the existing pending release to resolve.',
+  },
+  176: {
+    code: 'NoPendingOracleRelease',
+    message: 'No pending oracle release exists for this escrow.',
+    recovery: 'Call verify_delivery first.',
+  },
+  177: {
+    code: 'OracleChallengeWindowOpen',
+    message: 'The oracle challenge window has not yet elapsed.',
+    recovery: 'Wait until the recorded release_at ledger before retrying.',
+  },
 } as const;
 
 /**

--- a/sdk/types.ts
+++ b/sdk/types.ts
@@ -26,6 +26,7 @@ export const UNFUNDED_EXPIRY_LEDGERS = 120960;
 export const DEFAULT_EVIDENCE_WINDOW_LEDGERS = 34560;
 export const APPEAL_WINDOW_LEDGERS = 17280;
 export const DEFAULT_MEDIATION_WINDOW_LEDGERS = 34560;
+export const DEFAULT_ORACLE_CHALLENGE_WINDOW_LEDGERS = 17280;
 
 export type EscrowStatus =
   | 'Pending'
@@ -188,6 +189,13 @@ export interface MediationPhase {
   concluded: boolean;
 }
 
+export interface PendingOracleRelease {
+  escrow_id: number;
+  oracle: string;
+  verified_at: number;
+  release_at: number;
+}
+
 export type DataKey =
   | { Escrow: number }
   | 'EscrowCounter'
@@ -232,7 +240,8 @@ export type DataKey =
   | { MediationPhase: number }
   | { TokenPaused: string }
   | 'SchemaVersion'
-  | { EscrowSchemaVersion: number };
+  | { EscrowSchemaVersion: number }
+  | { PendingOracleRelease: number };
 
 export interface EscrowCreatedEvent {
   escrow_id: number;
@@ -254,6 +263,7 @@ export interface FundsReleasedEvent {
 export interface DeliveryVerifiedEvent {
   escrow_id: number;
   tracking_id: string;
+  release_at: number;
 }
 
 export interface FeeCollectedEvent {


### PR DESCRIPTION
## Summary

Fixes [#244](https://github.com/MarketXpress/MarketX-contract/issues/244) — a single compromised or misbehaving oracle could drain any tracked escrow via one `verify_delivery` call, with no dispute window and no buyer recourse.

`verify_delivery` no longer transfers funds directly. It now records intent, and a challenge window must elapse — during which the buyer can veto the release — before funds actually move.

## Changes

### `contracts/marketx/src/lib.rs`
- **`verify_delivery(escrow_id)`** — oracle-only, unchanged auth/state checks, but now only records a `PendingOracleRelease { escrow_id, oracle, verified_at, release_at }` (window = `DEFAULT_ORACLE_CHALLENGE_WINDOW_LEDGERS`, ~24h) and emits `DeliveryVerifiedEvent`. No token transfer happens here anymore. Rejects a second call while a release is already pending (`OracleReleasePending`).
- **`execute_oracle_release(escrow_id)`** *(new, permissionless)* — finalizes the transfer once `release_at` has passed (`OracleChallengeWindowOpen` if too early). Re-checks the escrow is still `Pending`/`Funded` before paying out; if the buyer disputed it in the meantime (via the existing `refund_escrow`, which flips status to `Disputed`), this fails with `InvalidEscrowState` and permanently blocks — escrows never return to `Pending`/`Funded` from `Disputed`, so a stale pending record can never later execute.
- **`get_pending_oracle_release(escrow_id)`** *(new)* — read helper mirroring the existing window-getter pattern (`get_evidence_window`, `get_mediation_phase`).

### `contracts/marketx/src/types.rs`
- `PendingOracleRelease` struct + `DataKey::PendingOracleRelease(u64)` variant.
- `DEFAULT_ORACLE_CHALLENGE_WINDOW_LEDGERS: u32 = 17_280` (~24h at 5s/ledger).
- `DeliveryVerifiedEvent` gained a `release_at: u32` field (previously defined but never emitted).

### `contracts/marketx/src/errors.rs`
Three new `ContractError` variants, continuing the existing discriminant sequence:

| Code | Variant | Meaning |
|---|---|---|
| 175 | `OracleReleasePending` | Oracle already has an unresolved pending release for this escrow |
| 176 | `NoPendingOracleRelease` | No pending oracle release exists for this escrow |
| 177 | `OracleChallengeWindowOpen` | Challenge window hasn't elapsed yet |

### `contracts/marketx/src/test.rs`
- `test_oracle_verified_delivery_release` *(updated)* — verify → no transfer yet, status stays `Funded` → too-early `execute_oracle_release` rejected → advance ledger past window → execute succeeds, funds move to seller.
- `test_oracle_release_blocked_by_buyer_dispute` *(new)* — buyer calls `refund_escrow` within the challenge window; after the window elapses, `execute_oracle_release` still fails and funds remain in the contract — no drain.
- `test_verify_delivery_rejects_duplicate_pending_release` *(new)* — oracle can't stack a second pending release on the same escrow.

### Docs/SDK (kept in sync per `CONTRIBUTING.md`'s error-code convention)
- `docs/error-codes.md` — new "Oracle Release Challenge Window (175–177)" section.
- `sdk/error-codes.ts` — corresponding `MARKETX_ERRORS` entries.
- `sdk/types.ts` — `PendingOracleRelease` interface, `DEFAULT_ORACLE_CHALLENGE_WINDOW_LEDGERS` constant, `DataKey` union entry, `DeliveryVerifiedEvent.release_at` field.

## Test Plan

- [x] `cargo test` — 104 unit tests + 2 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build --target wasm32v1-none --release` — builds successfully
- [x] New tests cover: dispute raised within window blocks release; release proceeds normally with no dispute


Closes #244 