### PR TITLE
fix: repair broken merge that left CI non-compiling on main

### DIFF
--- a/contracts/marketx/src/lib.rs
+++ b/contracts/marketx/src/lib.rs
@@ -193,19 +193,6 @@ impl Contract {
         Ok(())
     }
 
-    fn assert_token_not_paused(env: &Env, token: &Address) -> Result<(), ContractError> {
-        let is_paused: bool = env
-            .storage()
-            .persistent()
-            .get(&DataKey::TokenCircuitBreaker(token.clone()))
-            .unwrap_or(false);
-
-        if is_paused {
-            return Err(ContractError::ContractPaused);
-        }
-        Ok(())
-    }
-
     fn assert_disputes_enabled(env: &Env) -> Result<(), ContractError> {
         if !Self::disputes_enabled(env) {
             return Err(ContractError::FeatureDisabled);
@@ -882,19 +869,18 @@ impl Contract {
 
     /// Returns a structured summary containing comprehensive contract state metrics.
     pub fn analytics_summary(env: Env) -> GlobalDisputeAnalytics {
+        let total_escrows = Self::get_total_escrows(env.clone());
+        let released_count = Self::get_total_released_count(env.clone());
+        let refunded_count = Self::get_total_refunded_count(env.clone());
+        let disputed_count = Self::get_total_disputed_count(env.clone());
+        let cancelled_count = Self::get_total_cancelled_count(env.clone());
+
+        let failures = refunded_count + disputed_count + cancelled_count;
+        let failure_rate_bps = ((failures as u64) * 10_000)
+            .checked_div(total_escrows)
+            .unwrap_or(0) as u32;
+
         GlobalDisputeAnalytics {
-            total_escrows: Self::get_total_escrows(env.clone()),
-            total_funded_amount: Self::get_total_funded_amount(env.clone()),
-            total_released_amount: Self::get_total_released_amount(env.clone()),
-            total_refunded_amount: env.storage().persistent().get(&DataKey::TotalRefundedAmount).unwrap_or(0),
-            total_released_count: Self::get_total_released_count(env.clone()),
-            total_refunded_count: Self::get_total_refunded_count(env.clone()),
-            total_disputed_count: Self::get_total_disputed_count(env.clone()),
-            total_cancelled_count: Self::get_total_cancelled_count(env.clone()),
-            total_fees_collected: env.storage().persistent().get(&DataKey::TotalFeesCollected).unwrap_or(0),
-        }
-    }
-}
             total_escrows,
             released_count,
             refunded_count,

--- a/contracts/marketx/src/test.rs
+++ b/contracts/marketx/src/test.rs
@@ -3237,25 +3237,3 @@ fn test_mediation_no_agreement_does_not_settle() {
     let escrow = client.get_escrow(&escrow_id).unwrap();
     assert_eq!(escrow.status, crate::types::EscrowStatus::Disputed);
 }
-
-#![cfg(test)]
-use super::{MarketXContract, MarketXContractClient, Error};
-use crate::types::{Escrow, EscrowStatus, DataKey};
-use soroban_sdk::{contract, contractimpl, Env, Address, symbol_short};
-
-// Mock malicious token that attempts to call back into MarketX during a transfer
-#[contract]
-pub struct MaliciousToken;
-
-#[contractimpl]
-impl MaliciousToken {
-    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
-        // Attempt a malicious recursive execution back into the caller contract
-        let marketx_id = env.ledger().get_template_context(); // Assuming standard test reference
-        let client = MarketXContractClient::new(&env, &marketx_id);
-        
-        // This structural recursion path must cleanly abort due to the transient guard lock
-        let exploit_call = client.try_release_escrow(&0, &to);
-        assert!(exploit_call.is_err());
-    }
-}

--- a/contracts/marketx/src/types.rs
+++ b/contracts/marketx/src/types.rs
@@ -868,29 +868,3 @@ pub struct DisputeConsensusReachedEvent {
     pub votes_for_release: u32,
     pub votes_for_refund: u32,
 }
-
-#[derive(Clone)]
-#[contracttype]
-pub enum DataKey {
-    Escrow(u64),          // Maps an escrow ID to its State
-    ReentrancyLock,       // The operational execution guard key
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[contracttype]
-pub enum EscrowStatus {
-    Active,
-    Completed,
-    Disputed,
-    Refunded,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct Escrow {
-    pub id: u64,
-    pub token: Address,
-    pub amount: i128,
-    pub status: EscrowStatus,
-    // Other escrow fields...
-}


### PR DESCRIPTION
PR #248's merge into main duplicated the Escrow/EscrowStatus/DataKey type definitions and assert_token_not_paused, and left a stray closing brace plus orphaned fragment in analytics_summary. Removes the dead duplicate/scaffold code (none of it was reachable or tested) and restores the correct analytics_summary body. All CI checks (fmt, clippy, build, tests, wasm build) now pass locally.