### PR TITLE
fix: add arbiter conflict of interest error handling and tests

### DIFF
--- a/contracts/marketx/src/errors.rs
+++ b/contracts/marketx/src/errors.rs
@@ -82,4 +82,6 @@ pub enum ContractError {
     MigrationStorageError = 173,
     /// Migration failed: invalid migration target version.
     MigrationInvalidTargetVersion = 174,
+    /// Arbiter address matches the escrow's buyer or seller (#243).
+    ArbiterConflictOfInterest = 175,
 }

--- a/contracts/marketx/src/lib.rs
+++ b/contracts/marketx/src/lib.rs
@@ -609,6 +609,9 @@ impl Contract {
         Self::check_zero_address(&env, &token)?;
         if let Some(ref a) = arbiter {
             Self::check_zero_address(&env, a)?;
+            if *a == buyer || *a == seller {
+                return Err(ContractError::ArbiterConflictOfInterest);
+            }
         }
 
         Self::assert_token_not_paused(&env, &token)?;
@@ -2667,6 +2670,15 @@ impl Contract {
         // Validate arbiters list
         if arbiters.is_empty() {
             return Err(ContractError::ArbiterStakeInsufficient);
+        }
+
+        // Reject any arbiter that is a party to the escrow — an arbiter who
+        // is also the buyer or seller could rule in their own favor with no
+        // independent check (#243).
+        for arbiter in arbiters.iter() {
+            if arbiter == escrow.buyer || arbiter == escrow.seller {
+                return Err(ContractError::ArbiterConflictOfInterest);
+            }
         }
 
         let max_arbiters = env

--- a/contracts/marketx/src/test.rs
+++ b/contracts/marketx/src/test.rs
@@ -2711,6 +2711,85 @@ fn test_create_escrow_rejects_zero_arbiter() {
 }
 
 #[test]
+fn test_create_escrow_rejects_arbiter_equal_to_buyer_or_seller() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &250, &0, &0);
+
+    // Buyer appointing themselves as arbiter must be rejected.
+    let result = client.try_create_escrow(
+        &buyer,
+        &seller,
+        &token,
+        &1000,
+        &None,
+        &Some(buyer.clone()),
+        &None,
+        &None,
+    );
+    assert_eq!(result, Err(Ok(ContractError::ArbiterConflictOfInterest)));
+
+    // Seller appointed as arbiter must also be rejected.
+    let result = client.try_create_escrow(
+        &buyer,
+        &seller,
+        &token,
+        &1000,
+        &None,
+        &Some(seller.clone()),
+        &None,
+        &None,
+    );
+    assert_eq!(result, Err(Ok(ContractError::ArbiterConflictOfInterest)));
+}
+
+#[test]
+fn test_configure_multi_arbiters_rejects_conflicted_arbiter() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let token = Address::generate(&env);
+    let honest_arbiter = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &250, &0, &0);
+
+    let escrow_id =
+        client.create_escrow(&buyer, &seller, &token, &1000, &None, &None, &None, &None);
+
+    // Buyer tries to sneak themselves into the multi-arbiter set.
+    let mut arbiters = Vec::new(&env);
+    arbiters.push_back(honest_arbiter.clone());
+    arbiters.push_back(buyer.clone());
+
+    let result = client.try_configure_multi_arbiters(&escrow_id, &arbiters, &2);
+    assert_eq!(result, Err(Ok(ContractError::ArbiterConflictOfInterest)));
+
+    // Seller in the set is rejected too.
+    let mut arbiters = Vec::new(&env);
+    arbiters.push_back(honest_arbiter.clone());
+    arbiters.push_back(seller.clone());
+
+    let result = client.try_configure_multi_arbiters(&escrow_id, &arbiters, &2);
+    assert_eq!(result, Err(Ok(ContractError::ArbiterConflictOfInterest)));
+
+    // A clean set of independent arbiters is accepted.
+    let other_arbiter = Address::generate(&env);
+    let mut arbiters = Vec::new(&env);
+    arbiters.push_back(honest_arbiter);
+    arbiters.push_back(other_arbiter);
+
+    client.configure_multi_arbiters(&escrow_id, &arbiters, &2);
+    assert!(client.get_arbiters_config(&escrow_id).is_some());
+}
+
+#[test]
 fn test_create_bulk_escrows_rejects_zero_buyer() {
     let (env, client) = setup();
     let admin = Address::generate(&env);

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -157,6 +157,14 @@ Size limits enforced by error 60:
 
 ---
 
+## Dispute Resolution — Arbiter Conflict of Interest (175)
+
+| Code | Variant | Message | Recovery hint |
+|------|---------|---------|---------------|
+| 175 | `ArbiterConflictOfInterest` | The arbiter address matches the escrow's buyer or seller. | Choose an arbiter that is not a party to the escrow. |
+
+---
+
 ## Updating this document
 
 When adding a new `ContractError` variant:

--- a/sdk/error-codes.ts
+++ b/sdk/error-codes.ts
@@ -307,6 +307,12 @@ export const MARKETX_ERRORS: Readonly<Record<number, ContractErrorInfo>> = {
     message: 'Migration failed: invalid migration target version.',
     recovery: '',
   },
+  // ── Dispute Resolution — Arbiter Conflict of Interest ───────────────────────
+  175: {
+    code: 'ArbiterConflictOfInterest',
+    message: "The arbiter address matches the escrow's buyer or seller.",
+    recovery: 'Choose an arbiter that is not a party to the escrow.',
+  },
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Fixes [#243](https://github.com/MarketXpress/MarketX-contract/issues/243) — neither `create_escrow` nor `configure_multi_arbiters` checked that an arbiter address differed from the escrow's buyer or seller. A party could appoint themselves (or a colluding address) as arbiter, then call `resolve_dispute` to rule in their own favor with no independent check.

Both entrypoints now reject an arbiter that is a party to the escrow, returning a dedicated `ArbiterConflictOfInterest` error instead of a generic one.

## Changes

### `contracts/marketx/src/errors.rs`
- Added `ArbiterConflictOfInterest = 175` — continuing the existing discriminant sequence.

### `contracts/marketx/src/lib.rs`
- **`create_escrow_internal`** (the shared choke point for both `create_escrow` and `create_bulk_escrows`) — now rejects `arbiter == buyer || arbiter == seller`, checked right alongside the existing zero-address validation.
- **`configure_multi_arbiters`** — now loops over the proposed arbiter set and rejects any entry equal to the escrow's buyer or seller, before the max-arbiters/quorum checks.
- **`stake_as_arbiter`** — reviewed, needs no change: it only allows the address already recorded as `escrow.arbiter` to stake, so it inherits the fix transitively from `create_escrow`.

### `contracts/marketx/src/test.rs`
- `test_create_escrow_rejects_arbiter_equal_to_buyer_or_seller` *(new)* — covers both the buyer-as-arbiter and seller-as-arbiter cases.
- `test_configure_multi_arbiters_rejects_conflicted_arbiter` *(new)* — rejects a set containing the buyer, rejects a set containing the seller, and confirms a clean set of independent arbiters is still accepted.

### Docs/SDK (kept in sync per `CONTRIBUTING.md`'s error-code convention)
- `docs/error-codes.md` — new "Dispute Resolution — Arbiter Conflict of Interest (175)" section.
- `sdk/error-codes.ts` — corresponding `MARKETX_ERRORS` entry.

## Test Plan

- [x] `cargo test` — 104 unit tests + 2 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build --target wasm32v1-none --release` — builds successfully
- [x] New tests cover: `create_escrow` with arbiter == buyer/seller is rejected; `configure_multi_arbiters` rejects a conflicted arbiter in the set (both buyer and seller), while accepting a clean set

Closes #243 