### PR TITLE
fix: require funded escrows before payout actions

### DIFF
--- a/contracts/marketx/src/lib.rs
+++ b/contracts/marketx/src/lib.rs
@@ -415,6 +415,14 @@ impl Contract {
         escrow.items.iter().any(|item| item.released)
     }
 
+    fn assert_escrow_funded(escrow: &Escrow) -> Result<(), ContractError> {
+        if escrow.status != EscrowStatus::Funded {
+            return Err(ContractError::InvalidEscrowState);
+        }
+
+        Ok(())
+    }
+
     fn add_u32(env: &Env, key: DataKey) {
         let current: u32 = env.storage().persistent().get(&key).unwrap_or(0);
         env.storage().persistent().set(&key, &(current + 1));
@@ -1023,9 +1031,7 @@ impl Contract {
             .get(&DataKey::Escrow(escrow_id))
             .ok_or(ContractError::EscrowNotFound)?;
 
-        if escrow.status != EscrowStatus::Pending && escrow.status != EscrowStatus::Funded {
-            return Err(ContractError::InvalidEscrowState);
-        }
+        Self::assert_escrow_funded(&escrow)?;
 
         let tracking_id = escrow
             .tracking_id
@@ -1102,9 +1108,7 @@ impl Contract {
         // this escrow's outcome, and this call permanently fails (the escrow
         // can never return to Pending/Funded from a terminal or disputed
         // state, so this pending release can never execute).
-        if escrow.status != EscrowStatus::Pending && escrow.status != EscrowStatus::Funded {
-            return Err(ContractError::InvalidEscrowState);
-        }
+        Self::assert_escrow_funded(&escrow)?;
 
         let from_status = escrow.status.clone();
         let actor = pending.oracle.clone();
@@ -1359,7 +1363,7 @@ impl Contract {
             .get(&DataKey::Escrow(escrow_id))
             .ok_or(ContractError::EscrowNotFound)?;
 
-        // 2. Validate escrow is in Pending state
+        // 2. Validate escrow is in a fundable state
         if escrow.status != EscrowStatus::Pending && escrow.status != EscrowStatus::Funded {
             return Err(ContractError::InvalidEscrowState);
         }
@@ -1406,9 +1410,7 @@ impl Contract {
             .get(&DataKey::Escrow(escrow_id))
             .ok_or(ContractError::EscrowNotFound)?;
 
-        if escrow.status != EscrowStatus::Pending && escrow.status != EscrowStatus::Funded {
-            return Err(ContractError::InvalidEscrowState);
-        }
+        Self::assert_escrow_funded(&escrow)?;
 
         escrow.buyer.require_auth();
         let actor = escrow.buyer.clone();
@@ -1460,7 +1462,7 @@ impl Contract {
     ///
     /// # Errors
     /// * `EscrowNotFound` - If the escrow doesn't exist
-    /// * `InvalidEscrowState` - If the escrow is not in Pending state
+    /// * `InvalidEscrowState` - If the escrow is not in Funded state
     /// * `ItemNotFound` - If the item index is out of bounds
     /// * `ItemAlreadyReleased` - If the item has already been released
     pub fn release_item(env: Env, escrow_id: u64, item_index: u32) -> Result<(), ContractError> {
@@ -1473,9 +1475,7 @@ impl Contract {
             .get(&DataKey::Escrow(escrow_id))
             .ok_or(ContractError::EscrowNotFound)?;
 
-        if escrow.status != EscrowStatus::Pending && escrow.status != EscrowStatus::Funded {
-            return Err(ContractError::InvalidEscrowState);
-        }
+        Self::assert_escrow_funded(&escrow)?;
 
         escrow.buyer.require_auth();
 
@@ -1548,9 +1548,7 @@ impl Contract {
             return Err(ContractError::Unauthorized);
         }
 
-        if (escrow.status != EscrowStatus::Pending && escrow.status != EscrowStatus::Funded)
-            || Self::has_released_items(&escrow)
-        {
+        if Self::assert_escrow_funded(&escrow).is_err() || Self::has_released_items(&escrow) {
             return Err(ContractError::InvalidEscrowState);
         }
 
@@ -1597,9 +1595,7 @@ impl Contract {
             return Err(ContractError::Unauthorized);
         }
 
-        if (escrow.status != EscrowStatus::Pending && escrow.status != EscrowStatus::Funded)
-            || Self::has_released_items(&escrow)
-        {
+        if Self::assert_escrow_funded(&escrow).is_err() || Self::has_released_items(&escrow) {
             return Err(ContractError::InvalidEscrowState);
         }
 
@@ -1646,9 +1642,7 @@ impl Contract {
             return Err(ContractError::Unauthorized);
         }
 
-        if escrow.status != EscrowStatus::Pending && escrow.status != EscrowStatus::Funded {
-            return Err(ContractError::InvalidEscrowState);
-        }
+        Self::assert_escrow_funded(&escrow)?;
 
         if amount <= 0 || amount > escrow.amount {
             return Err(ContractError::InvalidEscrowAmount);
@@ -3705,9 +3699,7 @@ impl Contract {
 
         escrow.buyer.require_auth();
 
-        if escrow.status != EscrowStatus::Pending && escrow.status != EscrowStatus::Funded {
-            return Err(ContractError::InvalidEscrowState);
-        }
+        Self::assert_escrow_funded(&escrow)?;
 
         if milestone_index >= escrow.milestones.len() {
             return Err(ContractError::MilestoneNotFound);
@@ -3802,9 +3794,7 @@ impl Contract {
         // Only buyer can set time lock in this version (restored for API compatibility)
         escrow.buyer.require_auth();
 
-        if escrow.status != EscrowStatus::Pending && escrow.status != EscrowStatus::Funded {
-            return Err(ContractError::InvalidEscrowState);
-        }
+        Self::assert_escrow_funded(&escrow)?;
 
         let time_lock = TimeLock {
             release_ledger,
@@ -3843,9 +3833,7 @@ impl Contract {
             .get(&DataKey::Escrow(escrow_id))
             .ok_or(ContractError::EscrowNotFound)?;
 
-        if escrow.status != EscrowStatus::Pending && escrow.status != EscrowStatus::Funded {
-            return Err(ContractError::InvalidEscrowState);
-        }
+        Self::assert_escrow_funded(&escrow)?;
 
         let time_lock = escrow
             .time_lock

--- a/contracts/marketx/src/test.rs
+++ b/contracts/marketx/src/test.rs
@@ -657,7 +657,7 @@ fn buyer_can_release_escrow() {
     env.mock_all_auths();
     client.initialize(&admin, &admin, &0, &0, &0);
 
-    token_admin.mint(&client.address, &1000);
+    token_admin.mint(&buyer, &1000);
 
     let escrow_id = client.create_escrow(
         &buyer,
@@ -670,6 +670,7 @@ fn buyer_can_release_escrow() {
         &None,
     );
 
+    client.fund_escrow(&escrow_id);
     client.release_escrow(&escrow_id);
 
     assert_eq!(token.balance(&seller), 1000);
@@ -703,6 +704,33 @@ fn release_fails_if_not_pending() {
             .persistent()
             .set(&crate::types::DataKey::Escrow(escrow_id), &escrow);
     });
+
+    let result = client.try_release_escrow(&escrow_id);
+    assert_eq!(result, Err(Ok(ContractError::InvalidEscrowState)));
+}
+
+#[test]
+fn release_fails_if_pending_unfunded() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0, &0, &0);
+
+    let escrow_id = client.create_escrow(
+        &buyer,
+        &seller,
+        &token_id.address(),
+        &1000,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
 
     let result = client.try_release_escrow(&escrow_id);
     assert_eq!(result, Err(Ok(ContractError::InvalidEscrowState)));
@@ -755,6 +783,39 @@ fn buyer_can_fund_escrow() {
 
     let escrow = client.get_escrow(&escrow_id).unwrap();
     assert_eq!(escrow.status, crate::types::EscrowStatus::Funded);
+}
+
+#[test]
+fn refund_fails_if_pending_unfunded() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0, &0, &0);
+
+    let escrow_id = client.create_escrow(
+        &buyer,
+        &seller,
+        &token_id.address(),
+        &1000,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let result = client.try_refund_escrow(
+        &escrow_id,
+        &buyer,
+        &1000,
+        &crate::types::RefundReason::Other,
+        &Bytes::from_slice(&env, b"refund-evidence"),
+    );
+    assert_eq!(result, Err(Ok(ContractError::InvalidEscrowState)));
 }
 
 #[test]
@@ -895,6 +956,44 @@ fn accept_cancellation_fails_without_prior_proposal() {
 }
 
 #[test]
+fn accept_cancellation_fails_if_pending_unfunded() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0, &0, &0);
+
+    let escrow_id = client.create_escrow(
+        &buyer,
+        &seller,
+        &token_id.address(),
+        &1000,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    env.as_contract(&client.address, || {
+        let mut escrow: crate::types::Escrow = env
+            .storage()
+            .persistent()
+            .get(&crate::types::DataKey::Escrow(escrow_id))
+            .unwrap();
+        escrow.cancellation_proposer = Some(buyer.clone());
+        env.storage()
+            .persistent()
+            .set(&crate::types::DataKey::Escrow(escrow_id), &escrow);
+    });
+
+    let result = client.try_accept_cancellation(&escrow_id, &seller);
+    assert_eq!(result, Err(Ok(ContractError::InvalidEscrowState)));
+}
+
+#[test]
 fn cancellation_fails_after_partial_item_release() {
     let (env, client) = setup();
     let admin = Address::generate(&env);
@@ -919,7 +1018,7 @@ fn cancellation_fails_after_partial_item_release() {
         description: None,
     });
 
-    token_admin.mint(&client.address, &1000);
+    token_admin.mint(&buyer, &1000);
     let escrow_id = client.create_escrow(
         &buyer,
         &seller,
@@ -931,6 +1030,7 @@ fn cancellation_fails_after_partial_item_release() {
         &None,
     );
 
+    client.fund_escrow(&escrow_id);
     client.release_item(&escrow_id, &0u32);
 
     let result = client.try_propose_cancellation(&escrow_id, &buyer);
@@ -1040,7 +1140,7 @@ fn test_arbiter_can_resolve_dispute() {
     env.mock_all_auths();
     client.initialize(&admin, &admin, &0, &0, &0);
 
-    token_admin.mint(&client.address, &1000);
+    token_admin.mint(&buyer, &1000);
 
     let escrow_id = client.create_escrow(
         &buyer,
@@ -1052,6 +1152,8 @@ fn test_arbiter_can_resolve_dispute() {
         &None,
         &None,
     );
+
+    client.fund_escrow(&escrow_id);
 
     env.as_contract(&client.address, || {
         let mut escrow: crate::types::Escrow = env
@@ -1088,7 +1190,7 @@ fn test_release_emits_funds_and_status_change_events() {
 
     env.mock_all_auths();
     client.initialize(&admin, &admin, &0, &0, &0);
-    token_admin.mint(&client.address, &1000);
+    token_admin.mint(&buyer, &1000);
 
     let escrow_id = client.create_escrow(
         &buyer,
@@ -1100,6 +1202,7 @@ fn test_release_emits_funds_and_status_change_events() {
         &None,
         &None,
     );
+    client.fund_escrow(&escrow_id);
     client.release_escrow(&escrow_id);
 
     let events = env.events().all().filter_by_contract(&client.address);
@@ -1111,7 +1214,7 @@ fn test_release_emits_funds_and_status_change_events() {
     };
     let expected_status = StatusChangeEvent {
         escrow_id,
-        from_status: crate::types::EscrowStatus::Pending,
+        from_status: crate::types::EscrowStatus::Funded,
         to_status: crate::types::EscrowStatus::Released,
         actor: buyer,
     };
@@ -1140,7 +1243,7 @@ fn test_arbiter_can_refund_buyer_on_dispute() {
     env.mock_all_auths();
     client.initialize(&admin, &admin, &0, &0, &0);
 
-    token_admin.mint(&client.address, &1000);
+    token_admin.mint(&buyer, &1000);
 
     let escrow_id = client.create_escrow(
         &buyer,
@@ -1152,6 +1255,8 @@ fn test_arbiter_can_refund_buyer_on_dispute() {
         &None,
         &None,
     );
+
+    client.fund_escrow(&escrow_id);
 
     env.as_contract(&client.address, || {
         let mut escrow: crate::types::Escrow = env
@@ -1189,7 +1294,7 @@ fn test_resolve_dispute_emits_status_change_with_actor() {
 
     env.mock_all_auths();
     client.initialize(&admin, &admin, &0, &0, &0);
-    token_admin.mint(&client.address, &1000);
+    token_admin.mint(&buyer, &1000);
 
     let escrow_id = client.create_escrow(
         &buyer,
@@ -1201,6 +1306,8 @@ fn test_resolve_dispute_emits_status_change_with_actor() {
         &None,
         &None,
     );
+
+    client.fund_escrow(&escrow_id);
 
     env.as_contract(&client.address, || {
         let mut escrow: crate::types::Escrow = env
@@ -1548,8 +1655,7 @@ fn test_multi_item_escrow_creation_and_release() {
 
     let total_amount: i128 = 100_000_000; // 10 XLM
 
-    // Mint tokens to the contract for funding
-    token_admin.mint(&client.address, &total_amount);
+    token_admin.mint(&buyer, &total_amount);
 
     // Create escrow with items
     let escrow_id = client.create_escrow(
@@ -1562,6 +1668,8 @@ fn test_multi_item_escrow_creation_and_release() {
         &Some(items.clone()),
         &None,
     );
+
+    client.fund_escrow(&escrow_id);
 
     // Verify escrow was created with items
     let escrow = client.get_escrow(&escrow_id).unwrap();
@@ -1584,7 +1692,7 @@ fn test_multi_item_escrow_creation_and_release() {
     assert!(!escrow.items.get(1).unwrap().released);
     assert!(!escrow.items.get(2).unwrap().released);
     assert_eq!(token.balance(&seller), 30_000_000);
-    assert_eq!(escrow.status, crate::types::EscrowStatus::Pending); // Still pending
+    assert_eq!(escrow.status, crate::types::EscrowStatus::Funded); // Still funded
 
     // Release second item
     client.release_item(&escrow_id, &1u32);
@@ -1594,7 +1702,7 @@ fn test_multi_item_escrow_creation_and_release() {
     assert!(escrow.items.get(1).unwrap().released);
     assert!(!escrow.items.get(2).unwrap().released);
     assert_eq!(token.balance(&seller), 70_000_000);
-    assert_eq!(escrow.status, crate::types::EscrowStatus::Pending); // Still pending
+    assert_eq!(escrow.status, crate::types::EscrowStatus::Funded); // Still funded
 
     // Release third item - this should complete the escrow
     client.release_item(&escrow_id, &2u32);
@@ -1633,7 +1741,7 @@ fn test_release_item_already_released_fails() {
         description: None,
     });
 
-    token_admin.mint(&client.address, &50_000_000);
+    token_admin.mint(&buyer, &50_000_000);
 
     let escrow_id = client.create_escrow(
         &buyer,
@@ -1645,6 +1753,8 @@ fn test_release_item_already_released_fails() {
         &Some(items),
         &None,
     );
+
+    client.fund_escrow(&escrow_id);
 
     // Release item 0 first time
     client.release_item(&escrow_id, &0u32);
@@ -1675,7 +1785,7 @@ fn test_release_item_invalid_index_fails() {
         description: None,
     });
 
-    token_admin.mint(&client.address, &50_000_000);
+    token_admin.mint(&buyer, &50_000_000);
 
     let escrow_id = client.create_escrow(
         &buyer,
@@ -1687,6 +1797,8 @@ fn test_release_item_invalid_index_fails() {
         &Some(items),
         &None,
     );
+
+    client.fund_escrow(&escrow_id);
 
     // Try to release item with invalid index - should fail
     let result = client.try_release_item(&escrow_id, &5u32);
@@ -1782,8 +1894,7 @@ fn test_escrow_without_items_uses_full_release() {
     env.mock_all_auths();
     client.initialize(&admin, &admin, &0, &0, &0);
 
-    // Fund the contract so it can pay out
-    token_admin.mint(&client.address, &1000);
+    token_admin.mint(&buyer, &1000);
 
     // Create escrow without items (old behavior)
     let escrow_id = client.create_escrow(
@@ -1797,6 +1908,8 @@ fn test_escrow_without_items_uses_full_release() {
         &None,
     );
 
+    client.fund_escrow(&escrow_id);
+
     // Verify items is empty
     let escrow = client.get_escrow(&escrow_id).unwrap();
     assert_eq!(escrow.items.len(), 0);
@@ -1808,6 +1921,33 @@ fn test_escrow_without_items_uses_full_release() {
     assert_eq!(token.balance(&seller), 1000);
     let escrow = client.get_escrow(&escrow_id).unwrap();
     assert_eq!(escrow.status, crate::types::EscrowStatus::Released);
+}
+
+#[test]
+fn trigger_time_lock_release_fails_if_pending_unfunded() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0, &0, &0);
+
+    let escrow_id = client.create_escrow(
+        &buyer,
+        &seller,
+        &token_id.address(),
+        &1000,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let result = client.try_trigger_time_lock_release(&escrow_id);
+    assert_eq!(result, Err(Ok(ContractError::InvalidEscrowState)));
 }
 
 #[test]
@@ -2106,7 +2246,7 @@ fn test_fee_caps_min_fee() {
     // 5% fee, min 100, max 1000
     client.initialize(&admin, &collector, &500, &100, &1000);
 
-    token_admin.mint(&client.address, &1000);
+    token_admin.mint(&buyer, &1000);
 
     let escrow_id = client.create_escrow(
         &buyer,
@@ -2119,6 +2259,7 @@ fn test_fee_caps_min_fee() {
         &None,
     );
 
+    client.fund_escrow(&escrow_id);
     client.release_escrow(&escrow_id);
 
     // Normal fee = 1000 * 5% = 50. Min fee is 100.
@@ -2143,7 +2284,7 @@ fn test_fee_caps_max_fee() {
     // 5% fee, min 100, max 1000
     client.initialize(&admin, &collector, &500, &100, &1000);
 
-    token_admin.mint(&client.address, &50000);
+    token_admin.mint(&buyer, &50000);
 
     let escrow_id = client.create_escrow(
         &buyer,
@@ -2156,6 +2297,7 @@ fn test_fee_caps_max_fee() {
         &None,
     );
 
+    client.fund_escrow(&escrow_id);
     client.release_escrow(&escrow_id);
 
     // Normal fee = 50000 * 5% = 2500. Max fee is 1000.
@@ -2258,7 +2400,8 @@ fn test_whitelisted_buyer_pays_no_fee() {
     // 5% fee, min 100, max 1000
     client.initialize(&admin, &collector, &500, &100, &1000);
 
-    token_admin.mint(&client.address, &10000);
+    token_admin.mint(&buyer, &10000);
+    client.add_fee_whitelist(&buyer);
 
     let escrow_id = client.create_escrow(
         &buyer,
@@ -2271,12 +2414,11 @@ fn test_whitelisted_buyer_pays_no_fee() {
         &None,
     );
 
+    client.fund_escrow(&escrow_id);
     client.release_escrow(&escrow_id);
 
-    // Normal fee = 10000 * 5% = 500. Within [100, 1000].
-    // Seller should get 10000 - 500 = 9500.
-    assert_eq!(token.balance(&seller), 9500);
-    assert_eq!(client.get_pending_fee(&collector, &token_id.address()), 500);
+    assert_eq!(token.balance(&seller), 10000);
+    assert_eq!(client.get_pending_fee(&collector, &token_id.address()), 0);
 }
 
 #[test]
@@ -2403,9 +2545,9 @@ fn test_special_native_fee() {
 
     // 1. Check with non-native token (should be 5%)
     let other_token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &other_id.address());
-    other_token_admin.mint(&client.address, &10000);
-
     let buyer1 = Address::generate(&env);
+    other_token_admin.mint(&buyer1, &10000);
+
     let escrow_id_other = client.create_escrow(
         &buyer1,
         &seller,
@@ -2416,15 +2558,16 @@ fn test_special_native_fee() {
         &None,
         &None,
     );
+    client.fund_escrow(&escrow_id_other);
     client.release_escrow(&escrow_id_other);
     assert_eq!(client.get_pending_fee(&collector, &other_id.address()), 500);
 
     // 2. Check with native token (should be 1%)
     let native_token_admin =
         soroban_sdk::token::StellarAssetClient::new(&env, &native_id.address());
-    native_token_admin.mint(&client.address, &10000);
-
     let buyer2 = Address::generate(&env);
+    native_token_admin.mint(&buyer2, &10000);
+
     let escrow_id_native = client.create_escrow(
         &buyer2,
         &seller,
@@ -2435,6 +2578,7 @@ fn test_special_native_fee() {
         &None,
         &None,
     );
+    client.fund_escrow(&escrow_id_native);
     client.release_escrow(&escrow_id_native);
     assert_eq!(
         client.get_pending_fee(&collector, &native_id.address()),

--- a/contracts/marketx/test_snapshots/test/buyer_can_release_escrow.1.json
+++ b/contracts/marketx/test_snapshots/test/buyer_can_release_escrow.1.json
@@ -66,7 +66,7 @@
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "i128": "1000"
@@ -107,6 +107,46 @@
             }
           },
           "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "fund_escrow",
+              "args": [
+                {
+                  "u64": "1"
+                }
+              ]
+            }
+          },
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "i128": "1000"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
         }
       ]
     ],
@@ -626,7 +666,7 @@
               },
               "durability": "persistent",
               "val": {
-                "i128": "0"
+                "i128": "1000"
               }
             }
           },
@@ -822,6 +862,26 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
               "key": {
                 "ledger_key_nonce": {
+                  "nonce": "4270020994084947596"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
                   "nonce": "4837995959683129791"
                 }
               },
@@ -847,6 +907,58 @@
                   },
                   {
                     "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "amount"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "authorized"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "clawback"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 518400
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Balance"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                   }
                 ]
               },

--- a/contracts/marketx/test_snapshots/test/test_arbiter_can_refund_buyer_on_dispute.1.json
+++ b/contracts/marketx/test_snapshots/test/test_arbiter_can_refund_buyer_on_dispute.1.json
@@ -66,7 +66,7 @@
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "i128": "1000"
@@ -109,6 +109,46 @@
             }
           },
           "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "fund_escrow",
+              "args": [
+                {
+                  "u64": "1"
+                }
+              ]
+            }
+          },
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "i128": "1000"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
         }
       ]
     ],
@@ -719,7 +759,7 @@
               },
               "durability": "persistent",
               "val": {
-                "i128": "0"
+                "i128": "1000"
               }
             }
           },
@@ -871,6 +911,26 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
               "key": {
                 "ledger_key_nonce": {
+                  "nonce": "2032731177588607455"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
                   "nonce": "4837995959683129791"
                 }
               },
@@ -891,7 +951,7 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "2032731177588607455"
+                  "nonce": "4270020994084947596"
                 }
               },
               "durability": "temporary",

--- a/contracts/marketx/test_snapshots/test/test_arbiter_can_resolve_dispute.1.json
+++ b/contracts/marketx/test_snapshots/test/test_arbiter_can_resolve_dispute.1.json
@@ -66,7 +66,7 @@
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "i128": "1000"
@@ -109,6 +109,46 @@
             }
           },
           "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "fund_escrow",
+              "args": [
+                {
+                  "u64": "1"
+                }
+              ]
+            }
+          },
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "i128": "1000"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
         }
       ]
     ],
@@ -719,7 +759,7 @@
               },
               "durability": "persistent",
               "val": {
-                "i128": "0"
+                "i128": "1000"
               }
             }
           },
@@ -895,6 +935,26 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
               "key": {
                 "ledger_key_nonce": {
+                  "nonce": "2032731177588607455"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
                   "nonce": "4837995959683129791"
                 }
               },
@@ -915,7 +975,7 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "2032731177588607455"
+                  "nonce": "4270020994084947596"
                 }
               },
               "durability": "temporary",
@@ -977,6 +1037,58 @@
           "ext": "v0"
         },
         "live_until": 535681
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Balance"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "amount"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "authorized"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "clawback"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 518400
       },
       {
         "entry": {

--- a/contracts/marketx/test_snapshots/test/test_release_emits_funds_and_status_change_events.1.json
+++ b/contracts/marketx/test_snapshots/test/test_release_emits_funds_and_status_change_events.1.json
@@ -66,7 +66,7 @@
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "i128": "1000"
@@ -107,6 +107,46 @@
             }
           },
           "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "fund_escrow",
+              "args": [
+                {
+                  "u64": "1"
+                }
+              ]
+            }
+          },
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "i128": "1000"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
         }
       ]
     ],
@@ -624,7 +664,7 @@
               },
               "durability": "persistent",
               "val": {
-                "i128": "0"
+                "i128": "1000"
               }
             }
           },
@@ -820,6 +860,26 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
               "key": {
                 "ledger_key_nonce": {
+                  "nonce": "4270020994084947596"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
                   "nonce": "4837995959683129791"
                 }
               },
@@ -845,6 +905,58 @@
                   },
                   {
                     "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "amount"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "authorized"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "clawback"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 518400
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Balance"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                   }
                 ]
               },
@@ -1134,7 +1246,7 @@
                 {
                   "vec": [
                     {
-                      "symbol": "Pending"
+                      "symbol": "Funded"
                     }
                   ]
                 },

--- a/contracts/marketx/test_snapshots/test/test_resolve_dispute_emits_status_change_with_actor.1.json
+++ b/contracts/marketx/test_snapshots/test/test_resolve_dispute_emits_status_change_with_actor.1.json
@@ -66,7 +66,7 @@
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "i128": "1000"
@@ -109,6 +109,46 @@
             }
           },
           "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "fund_escrow",
+              "args": [
+                {
+                  "u64": "1"
+                }
+              ]
+            }
+          },
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "i128": "1000"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
         }
       ]
     ],
@@ -743,7 +783,7 @@
               },
               "durability": "persistent",
               "val": {
-                "i128": "0"
+                "i128": "1000"
               }
             }
           },
@@ -895,6 +935,26 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
               "key": {
                 "ledger_key_nonce": {
+                  "nonce": "2032731177588607455"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
                   "nonce": "4837995959683129791"
                 }
               },
@@ -915,7 +975,7 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "2032731177588607455"
+                  "nonce": "4270020994084947596"
                 }
               },
               "durability": "temporary",
@@ -952,6 +1012,58 @@
                     },
                     "val": {
                       "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "authorized"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "clawback"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 518400
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Balance"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "amount"
+                    },
+                    "val": {
+                      "i128": "0"
                     }
                   },
                   {


### PR DESCRIPTION
## Summary
Closes #253 

This change closes a payout vulnerability where multiple payout-adjacent flows accepted `Pending` escrows even though no funds had been deposited yet.

`create_escrow_internal` creates bookkeeping-only escrows in `Pending`, while `fund_escrow` is the step that actually transfers buyer funds into the contract and marks the escrow `Funded`. Several payout and payout-arming paths were incorrectly allowing `Pending || Funded`, which meant an unfunded escrow could trigger transfers out of the contract's pooled balance.

This PR changes those flows to require `EscrowStatus::Funded` before they can proceed.

## Changes

- Added a shared funded-state guard in [MarketX-contract/contracts/marketx/src/lib.rs](MarketX-contract/contracts/marketx/src/lib.rs#L418)
- Tightened payout and payout-arming flows to reject unfunded escrows:
  - [release_escrow](MarketX-contract/contracts/marketx/src/lib.rs#L1404)
  - [release_item](MarketX-contract/contracts/marketx/src/lib.rs#L1468)
  - [propose_cancellation](MarketX-contract/contracts/marketx/src/lib.rs#L1533)
  - [accept_cancellation](MarketX-contract/contracts/marketx/src/lib.rs#L1580)
  - [refund_escrow](MarketX-contract/contracts/marketx/src/lib.rs#L1621)
  - [verify_delivery](MarketX-contract/contracts/marketx/src/lib.rs#L1017)
  - [execute_oracle_release](MarketX-contract/contracts/marketx/src/lib.rs#L1085)
  - [complete_milestone](MarketX-contract/contracts/marketx/src/lib.rs#L3687)
  - [set_time_lock](MarketX-contract/contracts/marketx/src/lib.rs#L3781)
  - [trigger_time_lock_release](MarketX-contract/contracts/marketx/src/lib.rs#L3827)
- Kept actual funding flows permissive where needed, including `fund_escrow` and group-buy funding
- Updated happy-path tests that previously pre-minted to the contract and skipped funding
- Added regressions to ensure pending, never-funded escrows are rejected in the affected flows

## Tests

Added or updated coverage in [MarketX-contract/contracts/marketx/src/test.rs](MarketX-contract/contracts/marketx/src/test.rs#L647), including:

- [release_fails_if_pending_unfunded](MarketX-contract/contracts/marketx/src/test.rs#L713)
- [refund_fails_if_pending_unfunded](MarketX-contract/contracts/marketx/src/test.rs#L789)
- [accept_cancellation_fails_if_pending_unfunded](MarketX-contract/contracts/marketx/src/test.rs#L959)
- [trigger_time_lock_release_fails_if_pending_unfunded](MarketX-contract/contracts/marketx/src/test.rs#L1927)

Also updated existing release and fee-path tests to fund escrows before payout.

## Validation

- `cargo test -p marketx`
- Result: 110 unit tests passed, 2 integration tests passed

<img width="753" height="398" alt="image" src="https://github.com/user-attachments/assets/c3776a63-7208-4033-925b-11041c492042" />
