### PR TITLE
feat(security): require a timelock before contract upgrades

### DIFF
--- a/contracts/marketx/src/errors.rs
+++ b/contracts/marketx/src/errors.rs
@@ -92,4 +92,8 @@ pub enum ContractError {
     ArbiterConflictOfInterest = 178,
     /// Mediation window_ledgers exceeds MAX_MEDIATION_WINDOW_LEDGERS (#256).
     InvalidMediationWindow = 179,
+    /// No upgrade has been proposed, so there is nothing to execute or cancel (#242).
+    NoPendingUpgrade = 180,
+    /// The upgrade timelock has not yet elapsed (#242).
+    UpgradeTimelockNotElapsed = 181,
 }

--- a/contracts/marketx/src/lib.rs
+++ b/contracts/marketx/src/lib.rs
@@ -112,15 +112,16 @@ pub use types::{
     FeeCollectorRotatedEvent, FeeExemptionEvent, FeesWithdrawnEvent, FundsReleasedEvent,
     GlobalDisputeAnalytics, GroupBuy, GroupBuyCompletedEvent, GroupBuyFundedEvent,
     MediationOpenedEvent, MediationPhase, MediationProposedEvent, MediationSettledEvent,
-    MetadataVisibility, Milestone, MilestoneCompletedEvent, PendingOracleRelease,
+    MetadataVisibility, Milestone, MilestoneCompletedEvent, PendingOracleRelease, PendingUpgrade,
     RefundHistoryEntry, RefundReason, RefundRequest, RefundRequestedEvent, RefundStatus,
     StatusChangeEvent, StorageRentEstimate, TimeLock, TimeLockReleasedEvent,
-    TokenCircuitBreakerEvent, APPEAL_WINDOW_LEDGERS, CONTRACT_VERSION, CURRENT_SCHEMA_VERSION,
+    TokenCircuitBreakerEvent, UpgradeCancelledEvent, UpgradeExecutedEvent, UpgradeProposedEvent,
+    APPEAL_WINDOW_LEDGERS, CONTRACT_VERSION, CURRENT_SCHEMA_VERSION,
     DEFAULT_ARBITER_QUORUM_PERCENTAGE, DEFAULT_EVIDENCE_WINDOW_LEDGERS,
     DEFAULT_MAX_ARBITERS_PER_ESCROW, DEFAULT_MEDIATION_WINDOW_LEDGERS,
     DEFAULT_MIN_ARBITERS_REQUIRED, DEFAULT_ORACLE_CHALLENGE_WINDOW_LEDGERS, MAX_DESCRIPTION_SIZE,
     MAX_EVIDENCE_HASH_SIZE, MAX_ITEMS_PER_ESCROW, MAX_MEDIATION_WINDOW_LEDGERS, MAX_METADATA_SIZE,
-    MAX_TRACKING_ID_SIZE, UNFUNDED_EXPIRY_LEDGERS,
+    MAX_TRACKING_ID_SIZE, UNFUNDED_EXPIRY_LEDGERS, UPGRADE_TIMELOCK_LEDGERS,
 };
 
 #[cfg(test)]
@@ -3149,10 +3150,96 @@ impl Contract {
     // 🔧 ADMIN FUNCTIONS
     // =========================
 
-    /// Upgrade the contract WASM.
-    pub fn upgrade(env: Env, new_wasm_hash: soroban_sdk::BytesN<32>) -> Result<(), ContractError> {
+    /// Propose a contract WASM upgrade, starting the timelock (#242).
+    ///
+    /// The upgrade cannot take effect until `UPGRADE_TIMELOCK_LEDGERS` have
+    /// elapsed, giving escrow participants a window to observe the pending
+    /// change and exit. Proposing again replaces any existing proposal and
+    /// restarts the delay.
+    pub fn propose_upgrade(
+        env: Env,
+        new_wasm_hash: soroban_sdk::BytesN<32>,
+    ) -> Result<(), ContractError> {
         Self::assert_admin(&env)?;
-        env.deployer().update_current_contract_wasm(new_wasm_hash);
+
+        let now = env.ledger().sequence();
+        let pending = PendingUpgrade {
+            wasm_hash: new_wasm_hash.clone(),
+            proposed_at: now,
+            ready_at: now + UPGRADE_TIMELOCK_LEDGERS,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::PendingUpgrade, &pending);
+
+        UpgradeProposedEvent {
+            wasm_hash: new_wasm_hash,
+            proposed_at: pending.proposed_at,
+            ready_at: pending.ready_at,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Cancel a proposed upgrade before it executes (#242).
+    ///
+    /// This is the escape hatch for a proposal made in error, or one observed
+    /// during the timelock window and judged malicious.
+    pub fn cancel_upgrade(env: Env) -> Result<(), ContractError> {
+        Self::assert_admin(&env)?;
+
+        let pending: PendingUpgrade = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingUpgrade)
+            .ok_or(ContractError::NoPendingUpgrade)?;
+
+        env.storage().persistent().remove(&DataKey::PendingUpgrade);
+
+        UpgradeCancelledEvent {
+            wasm_hash: pending.wasm_hash,
+            cancelled_at: env.ledger().sequence(),
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Read the currently proposed upgrade, if any (#242).
+    ///
+    /// Public and unauthenticated on purpose: the timelock only protects escrow
+    /// participants if they can observe a pending WASM swap before it lands.
+    pub fn get_pending_upgrade(env: Env) -> Option<PendingUpgrade> {
+        env.storage().persistent().get(&DataKey::PendingUpgrade)
+    }
+
+    /// Execute a previously proposed upgrade once its timelock has elapsed (#242).
+    pub fn execute_upgrade(env: Env) -> Result<(), ContractError> {
+        Self::assert_admin(&env)?;
+
+        let pending: PendingUpgrade = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingUpgrade)
+            .ok_or(ContractError::NoPendingUpgrade)?;
+
+        let now = env.ledger().sequence();
+        if now < pending.ready_at {
+            return Err(ContractError::UpgradeTimelockNotElapsed);
+        }
+
+        env.storage().persistent().remove(&DataKey::PendingUpgrade);
+        env.deployer()
+            .update_current_contract_wasm(pending.wasm_hash.clone());
+
+        UpgradeExecutedEvent {
+            wasm_hash: pending.wasm_hash,
+            executed_at: now,
+        }
+        .publish(&env);
+
         Ok(())
     }
 

--- a/contracts/marketx/src/test.rs
+++ b/contracts/marketx/src/test.rs
@@ -2056,12 +2056,12 @@ fn test_upgrade_auth_failure() {
             address: &non_admin,
             invoke: &MockAuthInvoke {
                 contract: &client.address,
-                fn_name: "upgrade",
+                fn_name: "propose_upgrade",
                 args: (&new_wasm_hash,).into_val(&env),
                 sub_invokes: &[],
             },
         }])
-        .try_upgrade(&new_wasm_hash);
+        .try_propose_upgrade(&new_wasm_hash);
 
     assert!(result.is_err());
 }
@@ -2096,7 +2096,7 @@ fn test_upgrade_state_persistence() {
     assert_eq!(escrow.amount, 1000);
 
     let new_wasm_hash = soroban_sdk::BytesN::from_array(&env, &[0; 32]);
-    let _ = client.try_upgrade(&new_wasm_hash);
+    let _ = client.try_propose_upgrade(&new_wasm_hash);
 
     let escrow_after = client.get_escrow(&escrow_id).unwrap();
     assert_eq!(escrow_after.amount, 1000);
@@ -3510,4 +3510,161 @@ fn test_admin_can_cancel_mediation_and_force_resolve() {
 
     let escrow = client.get_escrow(&escrow_id).unwrap();
     assert_eq!(escrow.status, crate::types::EscrowStatus::Released);
+}
+
+// ── Upgrade timelock (#242) ──────────────────────────────────────────────────
+
+#[test]
+fn execute_upgrade_fails_before_timelock_elapses() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &collector, &250, &0, &0);
+
+    let new_wasm_hash = soroban_sdk::BytesN::from_array(&env, &[7; 32]);
+    client.propose_upgrade(&new_wasm_hash);
+
+    // One ledger short of the required delay.
+    env.ledger()
+        .with_mut(|l| l.sequence_number += crate::UPGRADE_TIMELOCK_LEDGERS - 1);
+
+    let result = client.try_execute_upgrade();
+    assert_eq!(result, Err(Ok(ContractError::UpgradeTimelockNotElapsed)));
+}
+
+#[test]
+fn proposed_upgrade_is_publicly_visible_with_its_ready_ledger() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &collector, &250, &0, &0);
+
+    assert_eq!(client.get_pending_upgrade(), None);
+
+    let proposed_at = env.ledger().sequence();
+    let new_wasm_hash = soroban_sdk::BytesN::from_array(&env, &[7; 32]);
+    client.propose_upgrade(&new_wasm_hash);
+
+    let pending = client.get_pending_upgrade().unwrap();
+    assert_eq!(pending.wasm_hash, new_wasm_hash);
+    assert_eq!(pending.proposed_at, proposed_at);
+    assert_eq!(
+        pending.ready_at,
+        proposed_at + crate::UPGRADE_TIMELOCK_LEDGERS
+    );
+}
+
+#[test]
+fn cancel_upgrade_clears_the_pending_proposal() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &collector, &250, &0, &0);
+
+    let new_wasm_hash = soroban_sdk::BytesN::from_array(&env, &[7; 32]);
+    client.propose_upgrade(&new_wasm_hash);
+    assert!(client.get_pending_upgrade().is_some());
+
+    client.cancel_upgrade();
+
+    assert_eq!(client.get_pending_upgrade(), None);
+
+    // Even once the original delay has passed, there is nothing to execute.
+    env.ledger()
+        .with_mut(|l| l.sequence_number += crate::UPGRADE_TIMELOCK_LEDGERS + 1);
+    assert_eq!(
+        client.try_execute_upgrade(),
+        Err(Ok(ContractError::NoPendingUpgrade))
+    );
+}
+
+#[test]
+fn reproposing_an_upgrade_restarts_the_timelock() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &collector, &250, &0, &0);
+
+    let first_hash = soroban_sdk::BytesN::from_array(&env, &[1; 32]);
+    client.propose_upgrade(&first_hash);
+
+    // Wait until the first proposal is almost executable, then swap the target.
+    env.ledger()
+        .with_mut(|l| l.sequence_number += crate::UPGRADE_TIMELOCK_LEDGERS - 1);
+
+    let second_hash = soroban_sdk::BytesN::from_array(&env, &[2; 32]);
+    client.propose_upgrade(&second_hash);
+
+    let pending = client.get_pending_upgrade().unwrap();
+    assert_eq!(pending.wasm_hash, second_hash);
+
+    // The new hash must serve a full delay of its own, not inherit the old one.
+    assert_eq!(
+        client.try_execute_upgrade(),
+        Err(Ok(ContractError::UpgradeTimelockNotElapsed))
+    );
+}
+
+#[test]
+fn execute_upgrade_fails_when_nothing_was_proposed() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &collector, &250, &0, &0);
+
+    assert_eq!(
+        client.try_execute_upgrade(),
+        Err(Ok(ContractError::NoPendingUpgrade))
+    );
+}
+
+#[test]
+fn non_admin_cannot_execute_or_cancel_an_upgrade() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &collector, &250, &0, &0);
+
+    let new_wasm_hash = soroban_sdk::BytesN::from_array(&env, &[7; 32]);
+    client.propose_upgrade(&new_wasm_hash);
+
+    env.ledger()
+        .with_mut(|l| l.sequence_number += crate::UPGRADE_TIMELOCK_LEDGERS + 1);
+
+    let execute_result = client
+        .mock_auths(&[MockAuth {
+            address: &non_admin,
+            invoke: &MockAuthInvoke {
+                contract: &client.address,
+                fn_name: "execute_upgrade",
+                args: ().into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .try_execute_upgrade();
+    assert!(execute_result.is_err());
+
+    let cancel_result = client
+        .mock_auths(&[MockAuth {
+            address: &non_admin,
+            invoke: &MockAuthInvoke {
+                contract: &client.address,
+                fn_name: "cancel_upgrade",
+                args: ().into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .try_cancel_upgrade();
+    assert!(cancel_result.is_err());
+
+    // The proposal survives both failed attempts.
+    assert!(client.get_pending_upgrade().is_some());
 }

--- a/contracts/marketx/src/types.rs
+++ b/contracts/marketx/src/types.rs
@@ -124,6 +124,8 @@ pub enum DataKey {
     DisputeVoting(u64),
     /// Pending oracle-triggered release awaiting its challenge window (#244).
     PendingOracleRelease(u64),
+    /// Contract upgrade proposed but not yet executed (#242).
+    PendingUpgrade,
 }
 
 pub const MAX_METADATA_SIZE: u32 = 1024;
@@ -870,4 +872,51 @@ pub struct DisputeConsensusReachedEvent {
     pub resolution: u32, // 0 = release to seller, 1 = refund to buyer
     pub votes_for_release: u32,
     pub votes_for_refund: u32,
+}
+
+// ─── Issue #242: Timelocked contract upgrades ────────────────────────────────
+
+/// Delay enforced between proposing and executing a contract upgrade
+/// (~48 hours at 5 s/ledger).
+///
+/// The window exists so that escrow participants can observe a pending WASM
+/// swap and exit before it takes effect. A compromised admin key therefore
+/// cannot replace the contract instantly.
+pub const UPGRADE_TIMELOCK_LEDGERS: u32 = 34_560;
+
+/// A contract upgrade that has been proposed but not yet executed (#242).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingUpgrade {
+    /// Hash of the WASM that will replace the current contract.
+    pub wasm_hash: BytesN<32>,
+    /// Ledger at which the upgrade was proposed.
+    pub proposed_at: u32,
+    /// Ledger at or after which the upgrade may be executed.
+    pub ready_at: u32,
+}
+
+#[contractevent(topics = ["upgrade_proposed"], data_format = "vec")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpgradeProposedEvent {
+    #[topic]
+    pub wasm_hash: BytesN<32>,
+    pub proposed_at: u32,
+    pub ready_at: u32,
+}
+
+#[contractevent(topics = ["upgrade_cancelled"], data_format = "vec")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpgradeCancelledEvent {
+    #[topic]
+    pub wasm_hash: BytesN<32>,
+    pub cancelled_at: u32,
+}
+
+#[contractevent(topics = ["upgrade_executed"], data_format = "vec")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpgradeExecutedEvent {
+    #[topic]
+    pub wasm_hash: BytesN<32>,
+    pub executed_at: u32,
 }

--- a/sdk/error-codes.ts
+++ b/sdk/error-codes.ts
@@ -329,6 +329,23 @@ export const MARKETX_ERRORS: Readonly<Record<number, ContractErrorInfo>> = {
     message: "The arbiter address matches the escrow's buyer or seller.",
     recovery: 'Choose an arbiter that is not a party to the escrow.',
   },
+  179: {
+    code: 'InvalidMediationWindow',
+    message: 'The requested mediation window exceeds the maximum allowed length.',
+    recovery: 'Request a window at or below MAX_MEDIATION_WINDOW_LEDGERS.',
+  },
+  // ── Timelocked Upgrades ────────────────────────────────────────────────────
+  180: {
+    code: 'NoPendingUpgrade',
+    message: 'No contract upgrade has been proposed.',
+    recovery: 'Call propose_upgrade before executing or cancelling an upgrade.',
+  },
+  181: {
+    code: 'UpgradeTimelockNotElapsed',
+    message: 'The upgrade timelock has not yet elapsed.',
+    recovery:
+      'Wait until the ready_at ledger reported by get_pending_upgrade before executing.',
+  },
 } as const;
 
 /**


### PR DESCRIPTION
`upgrade()` applied a new WASM hash the moment an admin called it. A compromised admin key could therefore replace the entire contract in a single transaction and drain every escrow, with no window for anyone to react.

Replace it with a three-step flow:

- `propose_upgrade(hash)` records the target and a `ready_at` ledger UPGRADE_TIMELOCK_LEDGERS (~48h) in the future
- `cancel_upgrade()` discards a pending proposal
- `execute_upgrade()` applies it, but only at or after `ready_at`

`get_pending_upgrade()` is public and unauthenticated so participants can observe a pending swap and exit during the window — without visibility the delay would protect no one. Re-proposing overwrites the target and restarts the full delay, so a proposal cannot be parked early and retargeted later.

Adds errors NoPendingUpgrade (180) and UpgradeTimelockNotElapsed (181), and syncs sdk/error-codes.ts, which was also missing 179 from an earlier change.

Tests: 6 new covering the timelock boundary, visibility, cancellation, restart-on-repropose, the empty-proposal path, and non-admin rejection.