### PR TITLE
fix: cap unbounded collections and convert panicking index access to …

### DIFF
--- a/contracts/marketx/src/lib.rs
+++ b/contracts/marketx/src/lib.rs
@@ -119,9 +119,10 @@ pub use types::{
     APPEAL_WINDOW_LEDGERS, CONTRACT_VERSION, CURRENT_SCHEMA_VERSION,
     DEFAULT_ARBITER_QUORUM_PERCENTAGE, DEFAULT_EVIDENCE_WINDOW_LEDGERS,
     DEFAULT_MAX_ARBITERS_PER_ESCROW, DEFAULT_MEDIATION_WINDOW_LEDGERS,
-    DEFAULT_MIN_ARBITERS_REQUIRED, DEFAULT_ORACLE_CHALLENGE_WINDOW_LEDGERS, MAX_DESCRIPTION_SIZE,
-    MAX_ESCROWS_PER_BATCH, MAX_EVIDENCE_HASH_SIZE, MAX_ITEMS_PER_ESCROW,
-    MAX_MEDIATION_WINDOW_LEDGERS, MAX_METADATA_SIZE, MAX_TRACKING_ID_SIZE, UNFUNDED_EXPIRY_LEDGERS,
+    DEFAULT_MIN_ARBITERS_REQUIRED, DEFAULT_ORACLE_CHALLENGE_WINDOW_LEDGERS,
+    MAX_BULK_ESCROWS_PER_CALL, MAX_DESCRIPTION_SIZE, MAX_ESCROWS_PER_BATCH, MAX_EVIDENCE_HASH_SIZE,
+    MAX_GROUP_BUY_BUYERS, MAX_ITEMS_PER_ESCROW, MAX_MEDIATION_WINDOW_LEDGERS, MAX_METADATA_SIZE,
+    MAX_MILESTONES_PER_ESCROW, MAX_PAGE_SIZE, MAX_TRACKING_ID_SIZE, UNFUNDED_EXPIRY_LEDGERS,
     UPGRADE_TIMELOCK_LEDGERS,
 };
 
@@ -211,6 +212,12 @@ impl Contract {
 
     fn add_i128(env: &Env, key: DataKey, value: i128) {
         let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        // These are contract-wide analytics counters (total funded/released/
+        // fees, etc.), incremented by per-escrow amounts that are themselves
+        // bounded by i128 token balances. Reaching i128::MAX would require
+        // aggregate volume many orders of magnitude beyond any real token
+        // supply, so this is unreachable in practice; `expect` documents the
+        // invariant instead of silently wrapping or truncating a stats value.
         let next = current.checked_add(value).expect("Global counter overflow");
         env.storage().persistent().set(&key, &next);
     }
@@ -289,7 +296,7 @@ impl Contract {
         token: &Address,
         seller: &Address,
         buyer: &Address,
-    ) -> i128 {
+    ) -> Result<i128, ContractError> {
         let fee = Self::calculate_fee_internal(env, amount, token, buyer);
         let seller_amount = amount - fee;
 
@@ -301,7 +308,7 @@ impl Contract {
                 .storage()
                 .persistent()
                 .get(&DataKey::FeeCollector)
-                .expect("Fee collector not configured");
+                .ok_or(ContractError::InvalidFeeConfig)?;
 
             Self::add_pending_fee(env, fee_collector.clone(), token.clone(), fee);
             Self::add_i128(env, DataKey::TotalFeesCollected, fee);
@@ -314,7 +321,7 @@ impl Contract {
             .publish(env);
         }
 
-        fee
+        Ok(fee)
     }
 
     fn validate_bytes_size(data: &Bytes, max: u32) -> Result<(), ContractError> {
@@ -684,6 +691,9 @@ impl Contract {
     }
 
     /// Create multiple escrows in a single transaction (Bulk Creation).
+    ///
+    /// # Errors
+    /// * `TooManyItems` - If `requests` exceeds `MAX_BULK_ESCROWS_PER_CALL`
     pub fn create_bulk_escrows(
         env: Env,
         buyer: Address,
@@ -692,6 +702,10 @@ impl Contract {
     ) -> Result<Vec<u64>, ContractError> {
         Self::assert_not_paused(&env)?;
         buyer.require_auth();
+
+        if requests.len() > MAX_BULK_ESCROWS_PER_CALL {
+            return Err(ContractError::TooManyItems);
+        }
 
         let mut ids = Vec::new(&env);
         for request in requests.iter() {
@@ -775,15 +789,13 @@ impl Contract {
             return Ok(());
         }
 
-        if caller == &escrow.buyer
-            || caller == &escrow.seller
-            || caller
-                == &env
-                    .storage()
-                    .persistent()
-                    .get::<DataKey, Address>(&DataKey::Admin)
-                    .unwrap()
-        {
+        let is_admin = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Address>(&DataKey::Admin)
+            .is_some_and(|admin| caller == &admin);
+
+        if caller == &escrow.buyer || caller == &escrow.seller || is_admin {
             return Ok(());
         }
 
@@ -803,6 +815,9 @@ impl Contract {
     }
 
     /// Get a paginated list of escrows.
+    ///
+    /// `limit` is clamped to `MAX_PAGE_SIZE` so a caller cannot force an
+    /// unbounded storage scan in a single call (#260).
     pub fn get_escrows(env: Env, start: u64, limit: u32) -> Vec<Option<Escrow>> {
         let counter: u64 = env
             .storage()
@@ -816,6 +831,7 @@ impl Contract {
             return result;
         }
 
+        let limit = limit.min(MAX_PAGE_SIZE);
         let end = (start + limit as u64 - 1).min(counter);
 
         for id in start..=end {
@@ -1456,7 +1472,7 @@ impl Contract {
             &escrow.token,
             &escrow.seller,
             &escrow.buyer,
-        );
+        )?;
 
         escrow.status = EscrowStatus::Released;
         escrow.cancellation_proposer = None;
@@ -1512,11 +1528,10 @@ impl Contract {
 
         escrow.buyer.require_auth();
 
-        if item_index as u32 >= escrow.items.len() {
-            return Err(ContractError::ItemNotFound);
-        }
-
-        let mut item = escrow.items.get(item_index as u32).unwrap();
+        let mut item = escrow
+            .items
+            .get(item_index)
+            .ok_or(ContractError::ItemNotFound)?;
         if item.released {
             return Err(ContractError::ItemAlreadyReleased);
         }
@@ -1531,7 +1546,7 @@ impl Contract {
             &escrow.token,
             &escrow.seller,
             &escrow.buyer,
-        );
+        )?;
 
         let all_released = escrow.items.iter().all(|i| i.released);
 
@@ -1978,7 +1993,7 @@ impl Contract {
                     &escrow.token,
                     &escrow.seller,
                     &escrow.buyer,
-                );
+                )?;
 
                 FundsReleasedEvent {
                     escrow_id,
@@ -3363,7 +3378,11 @@ impl Contract {
         // The proposed admin must authenticate this transaction
         proposed_admin.require_auth();
 
-        let old_admin: Address = env.storage().persistent().get(&DataKey::Admin).unwrap();
+        let old_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotAdmin)?;
 
         // Transfer the admin role
         env.storage()
@@ -3761,6 +3780,7 @@ impl Contract {
     /// * `arbiter` - Optional arbiter
     ///
     /// # Errors
+    /// * `TooManyItems` - If `milestones` exceeds `MAX_MILESTONES_PER_ESCROW`
     /// * `ItemAmountInvalid` - If milestone amounts don't sum to total amount
     pub fn create_milestone_escrow(
         env: Env,
@@ -3774,6 +3794,10 @@ impl Contract {
     ) -> Result<u64, ContractError> {
         Self::assert_not_paused(&env)?;
         buyer.require_auth();
+
+        if milestones.len() > MAX_MILESTONES_PER_ESCROW {
+            return Err(ContractError::TooManyItems);
+        }
 
         // Validate milestone amounts sum to total
         let milestone_sum: i128 = milestones.iter().map(|m| m.amount).sum();
@@ -3803,12 +3827,15 @@ impl Contract {
             .persistent()
             .set(&DataKey::MilestoneEscrow(escrow_id), &milestones);
 
-        // Update escrow with milestones
+        // Update escrow with milestones. `escrow_id` was just returned by
+        // `create_escrow_internal`, which stores the record before
+        // returning, so this lookup cannot miss in practice; the typed
+        // error is defensive rather than reachable.
         let mut escrow: Escrow = env
             .storage()
             .persistent()
             .get(&DataKey::Escrow(escrow_id))
-            .unwrap();
+            .ok_or(ContractError::EscrowNotFound)?;
         escrow.milestones = milestones;
         env.storage()
             .persistent()
@@ -3844,11 +3871,10 @@ impl Contract {
 
         Self::assert_escrow_funded(&escrow)?;
 
-        if milestone_index >= escrow.milestones.len() {
-            return Err(ContractError::MilestoneNotFound);
-        }
-
-        let mut milestone = escrow.milestones.get(milestone_index).unwrap();
+        let mut milestone = escrow
+            .milestones
+            .get(milestone_index)
+            .ok_or(ContractError::MilestoneNotFound)?;
         if milestone.completed {
             return Err(ContractError::MilestoneAlreadyCompleted);
         }
@@ -3864,7 +3890,7 @@ impl Contract {
             &escrow.token,
             &escrow.seller,
             &escrow.buyer,
-        );
+        )?;
 
         let all_completed = escrow.milestones.iter().all(|m| m.completed);
         if all_completed {
@@ -4002,7 +4028,7 @@ impl Contract {
             &escrow.token,
             &escrow.seller,
             &escrow.buyer,
-        );
+        )?;
 
         escrow.status = EscrowStatus::Released;
         env.storage()
@@ -4057,6 +4083,7 @@ impl Contract {
     /// * `arbiter` - Optional arbiter
     ///
     /// # Errors
+    /// * `TooManyItems` - If `buyers` exceeds `MAX_GROUP_BUY_BUYERS`
     /// * `InvalidGroupBuyAmount` - If buyer contributions don't sum to target amount
     pub fn create_group_buy_escrow(
         env: Env,
@@ -4069,6 +4096,10 @@ impl Contract {
         arbiter: Option<Address>,
     ) -> Result<u64, ContractError> {
         Self::assert_not_paused(&env)?;
+
+        if buyers.len() > MAX_GROUP_BUY_BUYERS {
+            return Err(ContractError::TooManyItems);
+        }
 
         // Validate buyer contributions sum to target
         let contributions_sum: i128 = buyers.iter().map(|b| b.amount).sum();
@@ -4104,12 +4135,15 @@ impl Contract {
             funding_deadline,
         };
 
-        // Update escrow with group buy config
+        // Update escrow with group buy config. `escrow_id` was just returned
+        // by `create_escrow_internal`, which stores the record before
+        // returning, so this lookup cannot miss in practice; the typed
+        // error is defensive rather than reachable.
         let mut escrow: Escrow = env
             .storage()
             .persistent()
             .get(&DataKey::Escrow(escrow_id))
-            .unwrap();
+            .ok_or(ContractError::EscrowNotFound)?;
         let mut gb_vec = Vec::new(&env);
         gb_vec.push_back(group_buy.clone());
         escrow.group_buy = gb_vec;
@@ -4179,8 +4213,13 @@ impl Contract {
         let token_client = soroban_sdk::token::Client::new(&env, &escrow.token);
         token_client.transfer(&buyer, env.current_contract_address(), &buyer_amount);
 
-        // Update buyer contribution
-        let mut contribution = group_buy.buyers.get(index).unwrap();
+        // Update buyer contribution. `index` was just found via `enumerate()`
+        // over this same vec, so it is always in bounds; the typed error is
+        // defensive rather than reachable.
+        let mut contribution = group_buy
+            .buyers
+            .get(index)
+            .ok_or(ContractError::Unauthorized)?;
         contribution.funded = true;
         group_buy.buyers.set(index, contribution);
         group_buy.funded_amount += buyer_amount;
@@ -4269,8 +4308,13 @@ impl Contract {
 
         let index = buyer_index.ok_or(ContractError::Unauthorized)?;
 
-        // Update state first (Effect)
-        let mut contribution = group_buy.buyers.get(index).unwrap();
+        // Update state first (Effect). `index` was just found via
+        // `enumerate()` over this same vec, so it is always in bounds; the
+        // typed error is defensive rather than reachable.
+        let mut contribution = group_buy
+            .buyers
+            .get(index)
+            .ok_or(ContractError::Unauthorized)?;
         contribution.funded = false;
         group_buy.buyers.set(index, contribution);
         group_buy.funded_amount -= buyer_amount;
@@ -4424,7 +4468,7 @@ impl Contract {
                     .storage()
                     .persistent()
                     .get(&DataKey::FeeCollector)
-                    .expect("Fee collector not configured");
+                    .ok_or(ContractError::InvalidFeeConfig)?;
                 Self::add_pending_fee(env, fee_collector.clone(), escrow.token.clone(), fee);
                 Self::add_i128(env, DataKey::TotalFeesCollected, fee);
                 FeeCollectedEvent {

--- a/contracts/marketx/src/test.rs
+++ b/contracts/marketx/src/test.rs
@@ -9,7 +9,10 @@ use soroban_sdk::{
 
 use crate::errors::ContractError;
 // MAX_METADATA_SIZE was warned as unused, but it's used later. Keep it.
-use crate::types::{EscrowItem, MAX_METADATA_SIZE};
+use crate::types::{
+    BuyerContribution, EscrowItem, Milestone, MAX_BULK_ESCROWS_PER_CALL, MAX_GROUP_BUY_BUYERS,
+    MAX_METADATA_SIZE, MAX_MILESTONES_PER_ESCROW, MAX_PAGE_SIZE,
+};
 use crate::{
     BulkEscrowRequest, Contract, ContractClient, EscrowCreatedEvent, FundsReleasedEvent,
     StatusChangeEvent,
@@ -3912,4 +3915,207 @@ fn non_admin_cannot_execute_or_cancel_an_upgrade() {
 
     // The proposal survives both failed attempts.
     assert!(client.get_pending_upgrade().is_some());
+}
+
+// ─── Issue #260: Input hardening — bounded collections & typed index errors ──
+
+#[test]
+fn test_complete_milestone_invalid_index_fails() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id.address());
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0, &0, &0);
+
+    let mut milestones = Vec::new(&env);
+    milestones.push_back(Milestone {
+        description: Bytes::new(&env),
+        amount: 50_000_000,
+        completed: false,
+        completed_at: None,
+    });
+
+    token_admin.mint(&buyer, &50_000_000);
+
+    let escrow_id = client.create_milestone_escrow(
+        &buyer,
+        &seller,
+        &token_id.address(),
+        &50_000_000,
+        &milestones,
+        &None,
+        &None,
+    );
+
+    client.fund_escrow(&escrow_id);
+
+    // Out-of-range milestone index must return a typed error, not panic.
+    let result = client.try_complete_milestone(&escrow_id, &5u32);
+    assert_eq!(result, Err(Ok(ContractError::MilestoneNotFound)));
+}
+
+#[test]
+fn test_create_milestone_escrow_rejects_too_many_milestones() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0, &0, &0);
+
+    let make_milestones = |count: u32| -> Vec<Milestone> {
+        let mut milestones = Vec::new(&env);
+        for _ in 0..count {
+            milestones.push_back(Milestone {
+                description: Bytes::new(&env),
+                amount: 1,
+                completed: false,
+                completed_at: None,
+            });
+        }
+        milestones
+    };
+
+    // Exactly MAX_MILESTONES_PER_ESCROW is accepted.
+    let escrow_id = client.create_milestone_escrow(
+        &buyer,
+        &seller,
+        &token,
+        &(MAX_MILESTONES_PER_ESCROW as i128),
+        &make_milestones(MAX_MILESTONES_PER_ESCROW),
+        &None,
+        &None,
+    );
+    assert!(client.get_escrow(&escrow_id).is_some());
+
+    // One over the limit is rejected with a typed error.
+    let result = client.try_create_milestone_escrow(
+        &buyer,
+        &seller,
+        &token,
+        &((MAX_MILESTONES_PER_ESCROW + 1) as i128),
+        &make_milestones(MAX_MILESTONES_PER_ESCROW + 1),
+        &None,
+        &None,
+    );
+    assert_eq!(result, Err(Ok(ContractError::TooManyItems)));
+}
+
+#[test]
+fn test_create_bulk_escrows_rejects_too_many_requests() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0, &0, &0);
+
+    let make_requests = |count: u32| -> Vec<BulkEscrowRequest> {
+        let mut requests = Vec::new(&env);
+        for _ in 0..count {
+            requests.push_back(BulkEscrowRequest {
+                seller: Address::generate(&env),
+                amount: 1,
+                metadata: None,
+                arbiter: None,
+                items: None,
+            });
+        }
+        requests
+    };
+
+    // Exactly MAX_BULK_ESCROWS_PER_CALL is accepted.
+    let ids = client.create_bulk_escrows(&buyer, &token, &make_requests(MAX_BULK_ESCROWS_PER_CALL));
+    assert_eq!(ids.len(), MAX_BULK_ESCROWS_PER_CALL);
+
+    // One over the limit is rejected with a typed error, not a resource trap.
+    let result = client.try_create_bulk_escrows(
+        &buyer,
+        &token,
+        &make_requests(MAX_BULK_ESCROWS_PER_CALL + 1),
+    );
+    assert_eq!(result, Err(Ok(ContractError::TooManyItems)));
+}
+
+#[test]
+fn test_create_group_buy_escrow_rejects_too_many_buyers() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0, &0, &0);
+
+    let make_buyers = |count: u32| -> Vec<BuyerContribution> {
+        let mut buyers = Vec::new(&env);
+        for _ in 0..count {
+            buyers.push_back(BuyerContribution {
+                buyer: Address::generate(&env),
+                amount: 1,
+                funded: false,
+            });
+        }
+        buyers
+    };
+
+    let deadline = env.ledger().sequence() + 1000;
+
+    // Exactly MAX_GROUP_BUY_BUYERS is accepted.
+    let escrow_id = client.create_group_buy_escrow(
+        &seller,
+        &token,
+        &(MAX_GROUP_BUY_BUYERS as i128),
+        &make_buyers(MAX_GROUP_BUY_BUYERS),
+        &deadline,
+        &None,
+        &None,
+    );
+    assert!(client.get_escrow(&escrow_id).is_some());
+
+    // One over the limit is rejected with a typed error.
+    let result = client.try_create_group_buy_escrow(
+        &seller,
+        &token,
+        &((MAX_GROUP_BUY_BUYERS + 1) as i128),
+        &make_buyers(MAX_GROUP_BUY_BUYERS + 1),
+        &deadline,
+        &None,
+        &None,
+    );
+    assert_eq!(result, Err(Ok(ContractError::TooManyItems)));
+}
+
+#[test]
+fn test_get_escrows_limit_clamped_to_max_page_size() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &admin, &0, &0, &0);
+
+    // Distinct sellers keep duplicate-escrow hashing from colliding.
+    let total = MAX_PAGE_SIZE + 10;
+    for _ in 0..total {
+        let seller = Address::generate(&env);
+        client.create_escrow(&buyer, &seller, &token, &1, &None, &None, &None, &None);
+    }
+
+    // A limit above MAX_PAGE_SIZE is silently clamped down to it.
+    let over_limit_page = client.get_escrows(&1, &(MAX_PAGE_SIZE + 50));
+    assert_eq!(over_limit_page.len(), MAX_PAGE_SIZE);
+
+    // A limit exactly at MAX_PAGE_SIZE still returns a full page.
+    let at_limit_page = client.get_escrows(&1, &MAX_PAGE_SIZE);
+    assert_eq!(at_limit_page.len(), MAX_PAGE_SIZE);
 }

--- a/contracts/marketx/src/types.rs
+++ b/contracts/marketx/src/types.rs
@@ -153,6 +153,38 @@ pub const MAX_ITEMS_PER_ESCROW: u32 = 50;
 /// `batch_collect_fees` call (#259).
 pub const MAX_ESCROWS_PER_BATCH: u32 = 50;
 
+/// Maximum number of escrows that may be returned by a single
+/// `get_escrows` page. Caller-supplied `limit` values above this are
+/// silently clamped rather than erroring, since pagination is a read-only
+/// convenience view and clamping keeps callers from being able to force an
+/// unbounded storage scan in one call (#260).
+///
+/// Each returned escrow is one read ledger entry, plus a handful of fixed
+/// entries (e.g. the escrow counter, the contract instance itself) read on
+/// every invocation. Soroban's current per-transaction footprint limit is
+/// ~100 unique ledger entries, so a page of 100 would already be at (or
+/// past) that ceiling with no room left for the fixed overhead — kept
+/// comfortably under it instead.
+pub const MAX_PAGE_SIZE: u32 = 50;
+
+/// Maximum number of requests that may be submitted in a single
+/// `create_bulk_escrows` call. Each request creates a full escrow record,
+/// so this bounds the resource cost of one transaction the same way
+/// `MAX_ITEMS_PER_ESCROW` bounds a single escrow's item list (#260).
+///
+/// Each escrow written costs 2 unique write entries (the `Escrow` record
+/// and its duplicate-prevention hash), plus the shared escrow counter.
+/// Soroban's current per-transaction write-entry limit is ~50, so this is
+/// kept well under the point where a full-size call would itself fail on a
+/// real network.
+pub const MAX_BULK_ESCROWS_PER_CALL: u32 = 20;
+
+/// Maximum number of milestones per `create_milestone_escrow` call (#260).
+pub const MAX_MILESTONES_PER_ESCROW: u32 = 50;
+
+/// Maximum number of buyers per `create_group_buy_escrow` call (#260).
+pub const MAX_GROUP_BUY_BUYERS: u32 = 50;
+
 /// Represents a single item/milestone within an escrow
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Summary

- Capped every unbounded, caller-supplied collection in the public API behind a typed `TooManyItems` error, following the existing `MAX_ITEMS_PER_ESCROW` precedent:
  - `get_escrows(limit)` — new `MAX_PAGE_SIZE` (50); over-limit values are silently clamped rather than erroring, since pagination is a read-only view.
  - `batch_collect_fees(escrow_ids)` — already capped by `MAX_ESCROWS_PER_BATCH` from #259; verified still enforced.
  - `create_bulk_escrows(requests)` — new `MAX_BULK_ESCROWS_PER_CALL` (20).
  - `create_milestone_escrow(milestones)` — new `MAX_MILESTONES_PER_ESCROW` (50).
  - `create_group_buy_escrow(buyers)` — new `MAX_GROUP_BUY_BUYERS` (50).
- `MAX_PAGE_SIZE` and `MAX_BULK_ESCROWS_PER_CALL` aren't arbitrary — they're sized to actually fit inside Soroban's per-transaction resource budget (~100 total footprint entries, ~50 write entries). A first pass at 100/50 looked "capped" but still blew the real ledger footprint/write budget in testing (a full-size call would fail on a real network even after the cap), so both were brought down with headroom.
- Converted every caller-reachable panicking index lookup (`.get(i).unwrap()`) into a typed error instead:
  - `release_item` → `ItemNotFound` (collapsed a separate bounds check + `unwrap()` into one `.get(...).ok_or(...)?`)
  - `complete_milestone` → `MilestoneNotFound` (same pattern)
  - `fund_group_buy` / `withdraw_group_buy_contribution` → `Unauthorized` on their internal buyer-contribution lookup (defensive — the index is derived from `enumerate()` over the same vec so it's always in bounds, but this removes the panic path entirely)
- Audited every remaining `unwrap()`/`expect()` in `lib.rs` per the issue's checklist:
  - `process_seller_transfer` and `execute_mediation_settlement`'s fee-collector lookups now return `ContractError::InvalidFeeConfig` instead of panicking if the contract was never initialized (`process_seller_transfer`'s signature changed to `Result<i128, ContractError>`; all 5 call sites updated to propagate with `?`)
  - `check_metadata_access`'s admin lookup no longer panics on an uninitialized contract
  - `accept_admin`'s admin lookup returns `NotAdmin` instead of panicking
  - `create_milestone_escrow` / `create_group_buy_escrow`'s post-creation escrow re-fetch returns `EscrowNotFound` instead of panicking (defensive — the record was just written by `create_escrow_internal`)
  - The one remaining `expect()` (`add_i128`'s counter-overflow guard) is left as-is with a comment explaining why it's unreachable in practice: it's a global `i128` analytics counter incremented by amounts bounded by real token supply, many orders of magnitude below `i128::MAX`.
- Added 5 tests: an out-of-range `complete_milestone` index, plus at-the-limit / over-the-limit coverage for each of the four new caps (milestones, bulk escrows, group-buy buyers, `get_escrows` page size).

## Scope note

The issue named `batch_collect_fees` and `get_escrows` explicitly. While implementing the fix I found the same unbounded-collection bug in three more entrypoints (`create_bulk_escrows`, `create_milestone_escrow`, `create_group_buy_escrow`) and fixed those too, since they're the identical bug class the issue is about ("harden all caller-supplied input"). Flagging this in case reviewers want it split out.

## Linked Issue

Closes #260 

## CI Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 128 unit tests + 2 integration tests pass (was 123 unit tests before this PR)
- [x] `./scripts/build_wasm.sh`

## Notes for Reviewers

- `process_seller_transfer` changing from `-> i128` to `-> Result<i128, ContractError>` is the widest-blast-radius change here — it's called from `release_escrow`, `release_item`, `claim_disputed_funds`, `complete_milestone`, and `trigger_time_lock_release`. All five call sites just gained a `?`; no behavior changes on the success path.
- The `fund_group_buy` / `withdraw_group_buy_contribution` index conversions are defensive rather than fixing a reachable bug — there's no public `index` parameter on those functions, the index is found internally via `enumerate()` over the buyer list. Included since the issue's technical context explicitly calls out those two line locations.
- Error code numbering is unchanged — only new error *usages* (`InvalidFeeConfig`, `TooManyItems`, `EscrowNotFound`, `Unauthorized`, `NotAdmin`) at existing variants, no new variants added.
